### PR TITLE
fix(db): track drizzle migration SQL despite legacy *.sql ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Drizzle migrations are source, not data dumps - exempt from *.sql
+!app/drizzle/*.sql

--- a/app/drizzle/0000_brave_the_fury.sql
+++ b/app/drizzle/0000_brave_the_fury.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS "app_meta" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" text NOT NULL
+);


### PR DESCRIPTION
The Jekyll-era root .gitignore's *.sql rule silently excluded the
migration from the image build; migrate-on-start then crash-looped
(No file ./drizzle/0000_brave_the_fury.sql). Negate the rule for
app/drizzle/ and commit the missing migration.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
