### PR TITLE
feat: SP1 Plan 2 - accounts via trusted-header identity + GDPR

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,2 +1,6 @@
 # PostgreSQL connection string used by the app and drizzle-kit
 DATABASE_URL=postgres://hungarian:hungarian@localhost:5433/hungarian
+
+# Local-dev identity (ignored when NODE_ENV=production). In production the
+# forward-auth gate asserts identity via the X-Forwarded-User header.
+DEV_USER_EMAIL=dev@localhost

--- a/app/drizzle/0001_cooing_iron_fist.sql
+++ b/app/drizzle/0001_cooing_iron_fist.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"display_name" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);

--- a/app/drizzle/meta/0001_snapshot.json
+++ b/app/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,91 @@
+{
+  "id": "b417d5d8-3241-4560-8c3b-dae1952e70b0",
+  "prevId": "5f0c0c90-4280-4059-a954-3daed082a5a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_meta": {
+      "name": "app_meta",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783267239962,
       "tag": "0000_brave_the_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783275299740,
+      "tag": "0001_cooing_iron_fist",
+      "breakpoints": true
     }
   ]
 }

--- a/app/e2e/account.spec.ts
+++ b/app/e2e/account.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+// The local compose stack has no forward-auth in front, so we assert the
+// gate contract directly: identity comes from X-Forwarded-User.
+const asJay = { 'X-Forwarded-User': 'e2e-jay@example.com' };
+
+test('account page requires identity', async ({ request }) => {
+  const anon = await request.get('/account');
+  expect(anon.status()).toBe(401);
+});
+
+test('account page shows the forwarded identity', async ({ request }) => {
+  const res = await request.get('/account', { headers: asJay });
+  expect(res.status()).toBe(200);
+  expect(await res.text()).toContain('e2e-jay@example.com');
+});
+
+test('export returns the user data as JSON attachment', async ({ request }) => {
+  const res = await request.get('/account/export', { headers: asJay });
+  expect(res.status()).toBe(200);
+  expect(res.headers()['content-disposition']).toContain('attachment');
+  const body = await res.json();
+  expect(body.user.email).toBe('e2e-jay@example.com');
+});
+
+test('delete removes the account and identity re-provisions', async ({ request }) => {
+  const before = await (await request.get('/account/export', { headers: asJay })).json();
+  const del = await request.post('/account?/delete', {
+    headers: { ...asJay, Origin: 'http://localhost:3000' },
+    form: {},
+    maxRedirects: 0
+  });
+  // Browsers get a 303; API-style clients get SvelteKit's JSON-serialized
+  // redirect with 200. Either way the outcome below is what matters.
+  expect([200, 302, 303]).toContain(del.status());
+  const after = await (await request.get('/account/export', { headers: asJay })).json();
+  expect(after.user.id).not.toBe(before.user.id);
+  expect(after.user.email).toBe('e2e-jay@example.com');
+});

--- a/app/src/app.d.ts
+++ b/app/src/app.d.ts
@@ -1,8 +1,12 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
+import type { User } from '$lib/server/db/schema';
+
 declare global {
   namespace App {
     // interface Error {}
-    // interface Locals {}
+    interface Locals {
+      user: User | null;
+    }
     // interface PageData {}
     // interface Platform {}
   }

--- a/app/src/hooks.server.ts
+++ b/app/src/hooks.server.ts
@@ -1,0 +1,12 @@
+import type { Handle } from '@sveltejs/kit';
+import { resolveUser } from '$lib/server/auth/resolve-user';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  // /health must stay dependency-free (no user lookup, no DB write).
+  if (event.url.pathname !== '/health') {
+    event.locals.user = await resolveUser(event);
+  } else {
+    event.locals.user = null;
+  }
+  return resolve(event);
+};

--- a/app/src/lib/server/auth/resolve-user.test.ts
+++ b/app/src/lib/server/auth/resolve-user.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./user-repo', () => ({
+  getOrCreateUserByEmail: vi.fn(async (email: string) => ({
+    id: 'uuid-1',
+    email,
+    displayName: null,
+    createdAt: new Date()
+  }))
+}));
+
+import { getOrCreateUserByEmail } from './user-repo';
+import { resolveUser } from './resolve-user';
+import type { RequestEvent } from '@sveltejs/kit';
+
+function eventWithHeaders(headers: Record<string, string>): RequestEvent {
+  return {
+    request: new Request('https://magyarul.nyolc.cc/', { headers })
+  } as unknown as RequestEvent;
+}
+
+const originalEnv = { ...process.env };
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv.NODE_ENV;
+  delete process.env.DEV_USER_EMAIL;
+  vi.clearAllMocks();
+});
+
+describe('resolveUser', () => {
+  it('provisions from X-Forwarded-User, lowercased', async () => {
+    const user = await resolveUser(eventWithHeaders({ 'X-Forwarded-User': 'Jay@Example.COM' }));
+    expect(user?.email).toBe('jay@example.com');
+    expect(getOrCreateUserByEmail).toHaveBeenCalledWith('jay@example.com');
+  });
+
+  it('returns null without header in production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DEV_USER_EMAIL = 'dev@localhost';
+    const user = await resolveUser(eventWithHeaders({}));
+    expect(user).toBeNull();
+    expect(getOrCreateUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it('falls back to DEV_USER_EMAIL outside production', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.DEV_USER_EMAIL = 'dev@localhost';
+    const user = await resolveUser(eventWithHeaders({}));
+    expect(user?.email).toBe('dev@localhost');
+  });
+
+  it('returns null with neither header nor fallback', async () => {
+    process.env.NODE_ENV = 'development';
+    const user = await resolveUser(eventWithHeaders({}));
+    expect(user).toBeNull();
+  });
+});

--- a/app/src/lib/server/auth/resolve-user.ts
+++ b/app/src/lib/server/auth/resolve-user.ts
@@ -1,0 +1,21 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import type { User } from '$lib/server/db/schema';
+import { getOrCreateUserByEmail } from './user-repo';
+
+/**
+ * Identity seam (SP1 Plan 2). Gated-testing implementation: trust the
+ * X-Forwarded-User email asserted by HAL's traefik-forward-auth gate
+ * (chain-oauth, whitelisted). Swapped for an in-app Google OAuth flow +
+ * session table at public launch — callers only ever see locals.user.
+ *
+ * Dev fallback: with no gate in front (local dev), DEV_USER_EMAIL
+ * provides an identity; it is ignored when NODE_ENV=production.
+ */
+export async function resolveUser(event: RequestEvent): Promise<User | null> {
+  let email = event.request.headers.get('x-forwarded-user');
+  if (!email && process.env.NODE_ENV !== 'production') {
+    email = process.env.DEV_USER_EMAIL ?? null;
+  }
+  if (!email) return null;
+  return getOrCreateUserByEmail(email.toLowerCase());
+}

--- a/app/src/lib/server/auth/user-repo.integration.test.ts
+++ b/app/src/lib/server/auth/user-repo.integration.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { getOrCreateUserByEmail, deleteUserById } from './user-repo';
+
+// Requires DATABASE_URL pointing at a running, migrated Postgres.
+describe.skipIf(!process.env.DATABASE_URL)('user repo', () => {
+  const email = `test-${Date.now()}@example.com`;
+
+  it('provisions a new user on first sight', async () => {
+    const user = await getOrCreateUserByEmail(email);
+    expect(user.email).toBe(email);
+    expect(user.id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('returns the same user on repeat calls (idempotent)', async () => {
+    const first = await getOrCreateUserByEmail(email);
+    const second = await getOrCreateUserByEmail(email);
+    expect(second.id).toBe(first.id);
+  });
+
+  it('deletes a user by id', async () => {
+    const user = await getOrCreateUserByEmail(email);
+    await deleteUserById(user.id);
+    const fresh = await getOrCreateUserByEmail(email);
+    expect(fresh.id).not.toBe(user.id);
+    await deleteUserById(fresh.id);
+  });
+});

--- a/app/src/lib/server/auth/user-repo.ts
+++ b/app/src/lib/server/auth/user-repo.ts
@@ -1,0 +1,24 @@
+import { getDb } from '$lib/server/db';
+import { users, type User } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Fetch-or-provision a user by email (the identity the forward-auth gate
+ * asserts). Concurrent-safe via ON CONFLICT DO NOTHING + re-select.
+ */
+export async function getOrCreateUserByEmail(email: string): Promise<User> {
+  const db = getDb();
+  const inserted = await db
+    .insert(users)
+    .values({ email })
+    .onConflictDoNothing({ target: users.email })
+    .returning();
+  if (inserted.length > 0) return inserted[0];
+  const existing = await db.select().from(users).where(eq(users.email, email));
+  if (existing.length === 0) throw new Error(`user upsert failed for ${email}`);
+  return existing[0];
+}
+
+export async function deleteUserById(id: string): Promise<void> {
+  await getDb().delete(users).where(eq(users.id, id));
+}

--- a/app/src/lib/server/db/schema.ts
+++ b/app/src/lib/server/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text } from 'drizzle-orm/pg-core';
+import { pgTable, text, uuid, timestamp } from 'drizzle-orm/pg-core';
 
 // Minimal table proving migrations run end-to-end.
 // Real domain tables arrive in later plans.
@@ -6,3 +6,15 @@ export const appMeta = pgTable('app_meta', {
   key: text('key').primaryKey(),
   value: text('value').notNull()
 });
+
+// Accounts (SP1 Plan 2). Identity arrives via trusted X-Forwarded-User
+// header during the gated testing phase; rows are auto-provisioned on
+// first authenticated request. See plans/2026-07-05-sp1-plan2-auth.md.
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  email: text('email').notNull().unique(),
+  displayName: text('display_name'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow()
+});
+
+export type User = typeof users.$inferSelect;

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -1,0 +1,5 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  return { user: locals.user ? { email: locals.user.email } : null };
+};

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,4 +1,14 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
 <main class="mx-auto max-w-3xl p-8">
   <h1 class="text-2xl font-bold text-teal-700">Learning Hungarian</h1>
   <p class="mt-2 text-slate-600">Platform foundation is running.</p>
+  {#if data.user}
+    <p class="mt-4 text-sm text-slate-600">
+      Signed in as <span class="font-semibold">{data.user.email}</span> ·
+      <a href="/account" class="text-teal-700 hover:underline">Your account</a>
+    </p>
+  {/if}
 </main>

--- a/app/src/routes/account/+page.server.ts
+++ b/app/src/routes/account/+page.server.ts
@@ -1,0 +1,19 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+import { deleteUserById } from '$lib/server/auth/user-repo';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw error(401, 'Not signed in');
+  const { id, email, displayName, createdAt } = locals.user;
+  return { user: { id, email, displayName, createdAt: createdAt.toISOString() } };
+};
+
+export const actions: Actions = {
+  // GDPR right to erasure. With trusted-header identity a fresh row is
+  // provisioned on the next authenticated visit — documented behavior.
+  delete: async ({ locals }) => {
+    if (!locals.user) throw error(401, 'Not signed in');
+    await deleteUserById(locals.user.id);
+    throw redirect(303, '/');
+  }
+};

--- a/app/src/routes/account/+page.svelte
+++ b/app/src/routes/account/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  let { data } = $props();
+  let confirming = $state(false);
+</script>
+
+<main class="mx-auto max-w-3xl p-8">
+  <a href="/" class="text-sm text-teal-700 hover:underline">&larr; Back</a>
+  <h1 class="mt-2 text-2xl font-bold text-teal-700">Your account</h1>
+
+  <dl class="mt-6 space-y-2 rounded-xl bg-white p-6 shadow-md">
+    <div>
+      <dt class="text-sm font-semibold text-slate-500">Email</dt>
+      <dd class="text-slate-700">{data.user.email}</dd>
+    </div>
+    <div>
+      <dt class="text-sm font-semibold text-slate-500">Member since</dt>
+      <dd class="text-slate-700">{new Date(data.user.createdAt).toLocaleDateString()}</dd>
+    </div>
+  </dl>
+
+  <section class="mt-8 rounded-xl bg-white p-6 shadow-md">
+    <h2 class="text-lg font-semibold text-slate-700">Your data</h2>
+    <p class="mt-1 text-sm text-slate-600">
+      Download everything we store about you, or delete your account entirely.
+    </p>
+    <div class="mt-4 flex gap-3">
+      <a
+        href="/account/export"
+        class="rounded-md bg-teal-700 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-800"
+        >Export my data</a
+      >
+      {#if !confirming}
+        <button
+          onclick={() => (confirming = true)}
+          class="rounded-md border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50"
+          >Delete my account</button
+        >
+      {:else}
+        <form method="POST" action="?/delete">
+          <button
+            type="submit"
+            class="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700"
+            >Really delete — this cannot be undone</button
+          >
+        </form>
+        <button onclick={() => (confirming = false)} class="px-2 text-sm text-slate-500 hover:underline"
+          >Cancel</button
+        >
+      {/if}
+    </div>
+  </section>
+</main>

--- a/app/src/routes/account/export/+server.ts
+++ b/app/src/routes/account/export/+server.ts
@@ -1,0 +1,18 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * GDPR data portability: everything we hold about the requesting user,
+ * as a JSON download. Later plans (progress, SRS, feedback) append their
+ * sections here — this endpoint is THE canonical exporter.
+ */
+export const GET: RequestHandler = async ({ locals }) => {
+  if (!locals.user) throw error(401, 'Not signed in');
+  const body = {
+    exportedAt: new Date().toISOString(),
+    user: locals.user
+  };
+  return json(body, {
+    headers: { 'Content-Disposition': 'attachment; filename="my-data-magyarul-nyolc-cc.json"' }
+  });
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-hungarian}:${POSTGRES_PASSWORD:-hungarian}@db:5432/${POSTGRES_DB:-hungarian}
       PORT: 3000
+      # SvelteKit CSRF origin check needs to know its own origin
+      ORIGIN: http://localhost:3000
     depends_on:
       db:
         condition: service_healthy

--- a/docs/superpowers/plans/2026-07-05-sp1-plan2-auth.md
+++ b/docs/superpowers/plans/2026-07-05-sp1-plan2-auth.md
@@ -1,0 +1,31 @@
+# SP1 Plan 2 — Auth & Accounts
+
+**Goal:** Accounts from day one, with GDPR export/delete, using the testing-phase gate Jaypaul chose.
+
+**Key design decision (2026-07-05):** While the site is gated behind HAL's
+`chain-oauth` (traefik-forward-auth, whitelisted to Jaypaul's Google account),
+the app derives identity from the **`X-Forwarded-User`** header the middleware
+forwards (verified: `authResponseHeaders: X-Forwarded-User` in
+`middlewares-oauth.yml`). No in-app OAuth flow, no Google Console changes, no
+password surface. The header is only spoofable from inside HAL's container
+networks — accepted for the gated phase, documented here.
+
+**Swap path at public launch:** identity resolution lives behind one seam —
+`resolveUser(event)` in `$lib/server/auth`. Launch replaces the
+trusted-header resolver with a full in-app Google OAuth flow (Arctic) +
+`session` table, reusing the stack's existing Google client (add redirect URI
+`https://magyarul.nyolc.cc/auth/google/callback` in Google Console — Jaypaul).
+Nothing else changes.
+
+## Tasks
+
+1. **users table + repo** — Drizzle migration: `users(id uuid pk default, email text unique not null, display_name text, created_at timestamptz default now())`. `getOrCreateUserByEmail(email): Promise<User>` (insert-on-conflict-return). Unit-tested against dev Postgres.
+2. **Trusted-header auth hook** — `hooks.server.ts`: read `X-Forwarded-User`; dev fallback `DEV_USER_EMAIL` when not production; `event.locals.user: User | null`. `/health` stays user-free. Tests: header present → user provisioned + attached; absent in prod → null; dev fallback works.
+3. **/account page + GDPR** — shows email/display name/created; **Export my data** (JSON download of user row — later plans append their tables to the same exporter registry); **Delete my account** (POST with confirm, cascades). Tests via Vitest (server actions) + Playwright (gated flow with header injection).
+4. **Deploy + verify** — merge → CI → HAL pull/up → verify live behind the gate.
+
+## DoD
+- [ ] Migration applies; users auto-provision on first authenticated request
+- [ ] locals.user available to all routes; dev fallback documented in .env.example
+- [ ] /account renders; export downloads JSON; delete removes row and re-provisions on next visit (documented behavior)
+- [ ] All tests green locally + Compose smoke; live check on magyarul.nyolc.cc


### PR DESCRIPTION
- **feat(auth): users table + provision-on-first-sight repo**
- **feat(auth): trusted-header identity, /account with GDPR export+delete**
