### PR TITLE
feat: SP1 Plan 3 - tier-aware content model + import pipeline

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,7 +14,8 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/build ./build
 COPY --from=build /app/drizzle ./drizzle
-COPY scripts/migrate.js ./scripts/migrate.js
+COPY scripts ./scripts
+COPY content ./content
 COPY docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 EXPOSE 3000

--- a/app/content/A1/foundation/_module.yaml
+++ b/app/content/A1/foundation/_module.yaml
@@ -1,0 +1,5 @@
+id: a1-foundation
+tier: A1
+title: Foundation
+description: The Hungarian alphabet, sounds, and your very first sentences.
+position: 0

--- a/app/content/A1/foundation/smoke-test.yaml
+++ b/app/content/A1/foundation/smoke-test.yaml
@@ -1,0 +1,47 @@
+# Pipeline smoke-test lesson — proves the import + engine end-to-end.
+# Replaced by real, MoE-validated content in SP1 Plan 6.
+id: a1-smoke-test
+title: Pipeline smoke test
+version: 1
+position: 0
+status: draft
+objectives:
+  - Prove the content pipeline end-to-end
+skills: [reading]
+sources:
+  - "internal: pipeline test content, not real instruction"
+blocks:
+  - type: prose
+    payload:
+      text: >-
+        This is a smoke-test lesson. If you can read this on the site, the
+        content pipeline (YAML -> import -> Postgres -> render) works.
+  - type: example
+    payload:
+      hungarian: "Szia!"
+      english: "Hi!"
+srsItems:
+  - id: "vocab:szia"
+    payload:
+      front: "szia"
+      back: "hi / bye (informal)"
+exercises:
+  - id: ex1
+    type: fill_blank
+    srs: ["vocab:szia"]
+    payload:
+      prompt: "___! Hogy vagy?"
+      answer: "Szia"
+      translation: "Hi! How are you?"
+  - id: ex2
+    type: mcq
+    payload:
+      prompt: "What does 'szia' mean?"
+      options: ["hello (informal)", "goodbye (formal)", "thank you"]
+      correctIndex: 0
+  - id: ex3
+    type: card_flip
+    srs: ["vocab:szia"]
+    payload:
+      front: "szia"
+      back: "hi / bye (informal)"

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -2,5 +2,7 @@
 set -e
 echo "Applying database migrations..."
 node scripts/migrate.js
+echo "Importing content..."
+node scripts/import-content.js
 echo "Starting server..."
 exec node build

--- a/app/drizzle/0002_messy_leopardon.sql
+++ b/app/drizzle/0002_messy_leopardon.sql
@@ -1,0 +1,99 @@
+CREATE TYPE "public"."cefr_tier" AS ENUM('A1', 'A2', 'B1', 'B2', 'C1', 'C2');--> statement-breakpoint
+CREATE TYPE "public"."lesson_status" AS ENUM('draft', 'reviewed', 'community_verified');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "assessments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tier" "cefr_tier" NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"position" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "content_blocks" (
+	"lesson_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	CONSTRAINT "content_blocks_lesson_id_position_pk" PRIMARY KEY("lesson_id","position")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "exercise_srs_items" (
+	"exercise_id" text NOT NULL,
+	"srs_item_id" text NOT NULL,
+	CONSTRAINT "exercise_srs_items_exercise_id_srs_item_id_pk" PRIMARY KEY("exercise_id","srs_item_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "exercises" (
+	"id" text PRIMARY KEY NOT NULL,
+	"lesson_id" text,
+	"assessment_id" text,
+	"position" integer NOT NULL,
+	"type" text NOT NULL,
+	"payload_schema_version" integer DEFAULT 1 NOT NULL,
+	"payload" jsonb NOT NULL,
+	"content_version" integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "lessons" (
+	"id" text PRIMARY KEY NOT NULL,
+	"module_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"title" text NOT NULL,
+	"objectives" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"prerequisites" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"skill_tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"status" "lesson_status" DEFAULT 'draft' NOT NULL,
+	"content_version" integer DEFAULT 1 NOT NULL,
+	"sources" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"provenance" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"estimated_minutes" integer
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "modules" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tier" "cefr_tier" NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"position" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "srs_items" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kind" text NOT NULL,
+	"payload" jsonb NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "content_blocks" ADD CONSTRAINT "content_blocks_lesson_id_lessons_id_fk" FOREIGN KEY ("lesson_id") REFERENCES "public"."lessons"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "exercise_srs_items" ADD CONSTRAINT "exercise_srs_items_exercise_id_exercises_id_fk" FOREIGN KEY ("exercise_id") REFERENCES "public"."exercises"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "exercise_srs_items" ADD CONSTRAINT "exercise_srs_items_srs_item_id_srs_items_id_fk" FOREIGN KEY ("srs_item_id") REFERENCES "public"."srs_items"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "exercises" ADD CONSTRAINT "exercises_lesson_id_lessons_id_fk" FOREIGN KEY ("lesson_id") REFERENCES "public"."lessons"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "exercises" ADD CONSTRAINT "exercises_assessment_id_assessments_id_fk" FOREIGN KEY ("assessment_id") REFERENCES "public"."assessments"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lessons" ADD CONSTRAINT "lessons_module_id_modules_id_fk" FOREIGN KEY ("module_id") REFERENCES "public"."modules"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/app/drizzle/meta/0002_snapshot.json
+++ b/app/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,549 @@
+{
+  "id": "ee5a058b-7d78-4d0e-879e-7f1116e05345",
+  "prevId": "b417d5d8-3241-4560-8c3b-dae1952e70b0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_meta": {
+      "name": "app_meta",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assessments": {
+      "name": "assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "cefr_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_blocks": {
+      "name": "content_blocks",
+      "schema": "",
+      "columns": {
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_blocks_lesson_id_lessons_id_fk": {
+          "name": "content_blocks_lesson_id_lessons_id_fk",
+          "tableFrom": "content_blocks",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "content_blocks_lesson_id_position_pk": {
+          "name": "content_blocks_lesson_id_position_pk",
+          "columns": [
+            "lesson_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_srs_items": {
+      "name": "exercise_srs_items",
+      "schema": "",
+      "columns": {
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "srs_item_id": {
+          "name": "srs_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_srs_items_exercise_id_exercises_id_fk": {
+          "name": "exercise_srs_items_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_srs_items",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exercise_srs_items_srs_item_id_srs_items_id_fk": {
+          "name": "exercise_srs_items_srs_item_id_srs_items_id_fk",
+          "tableFrom": "exercise_srs_items",
+          "tableTo": "srs_items",
+          "columnsFrom": [
+            "srs_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exercise_srs_items_exercise_id_srs_item_id_pk": {
+          "name": "exercise_srs_items_exercise_id_srs_item_id_pk",
+          "columns": [
+            "exercise_id",
+            "srs_item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_schema_version": {
+          "name": "payload_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_version": {
+          "name": "content_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercises_lesson_id_lessons_id_fk": {
+          "name": "exercises_lesson_id_lessons_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exercises_assessment_id_assessments_id_fk": {
+          "name": "exercises_assessment_id_assessments_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skill_tags": {
+          "name": "skill_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "lesson_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "content_version": {
+          "name": "content_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "cefr_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.srs_items": {
+      "name": "srs_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.cefr_tier": {
+      "name": "cefr_tier",
+      "schema": "public",
+      "values": [
+        "A1",
+        "A2",
+        "B1",
+        "B2",
+        "C1",
+        "C2"
+      ]
+    },
+    "public.lesson_status": {
+      "name": "lesson_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "reviewed",
+        "community_verified"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783275299740,
       "tag": "0001_cooing_iron_fist",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783275846191,
+      "tag": "0002_messy_leopardon",
+      "breakpoints": true
     }
   ]
 }

--- a/app/e2e/learn.spec.ts
+++ b/app/e2e/learn.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('curriculum page lists imported content with status badge', async ({ request }) => {
+  const res = await request.get('/learn', {
+    headers: { 'X-Forwarded-User': 'e2e-learn@example.com' }
+  });
+  expect(res.status()).toBe(200);
+  const html = await res.text();
+  expect(html).toContain('Foundation'); // module title
+  expect(html).toContain('Pipeline smoke test'); // lesson title
+  expect(html).toContain('draft'); // honest status badge
+});

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "drizzle-orm": "^0.36.4",
-        "pg": "^8.22.0"
+        "pg": "^8.22.0",
+        "yaml": "^2.9.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@playwright/test": "^1.47.0",
@@ -4500,12 +4502,36 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "test:e2e": "playwright test",
+    "content:import": "node scripts/import-content.js",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push"
@@ -36,6 +37,8 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.36.4",
-    "pg": "^8.22.0"
+    "pg": "^8.22.0",
+    "yaml": "^2.9.0",
+    "zod": "^3.25.76"
   }
 }

--- a/app/scripts/content-schema.mjs
+++ b/app/scripts/content-schema.mjs
@@ -1,0 +1,117 @@
+// Content validation schemas — plain JS + zod so BOTH the import script
+// (runtime image, no TS tooling) and the SvelteKit app (re-exported via
+// $lib/content) share one source of truth. Payloads are versioned and
+// type-discriminated: new exercise types (listening/speaking, SP3) are
+// additive — no schema migration.
+import { z } from 'zod';
+
+export const PAYLOAD_SCHEMA_VERSION = 1;
+
+const base = { translation: z.string().optional(), hint: z.string().optional() };
+
+export const exercisePayloads = {
+  fill_blank: z.object({
+    ...base,
+    prompt: z.string().min(1), // sentence containing ___
+    answer: z.string().min(1)
+  }),
+  mcq: z.object({
+    ...base,
+    prompt: z.string().min(1),
+    options: z.array(z.string().min(1)).min(2),
+    correctIndex: z.number().int().nonnegative()
+  }),
+  dropdown: z.object({
+    ...base,
+    prompt: z.string().min(1),
+    options: z.array(z.string().min(1)).min(2),
+    correct: z.string().min(1)
+  }),
+  card_flip: z.object({
+    ...base,
+    front: z.string().min(1),
+    back: z.string().min(1)
+  }),
+  sentence_build: z.object({
+    ...base,
+    words: z.array(z.string().min(1)).min(2),
+    answer: z.string().min(1)
+  }),
+  transform: z.object({
+    ...base,
+    prompt: z.string().min(1),
+    instruction: z.string().min(1),
+    answer: z.string().min(1)
+  }),
+  dialogue: z.object({
+    ...base,
+    intro: z.string().optional(),
+    gaps: z
+      .array(
+        z.object({
+          before: z.string(),
+          answer: z.string().min(1),
+          after: z.string(),
+          translation: z.string().optional()
+        })
+      )
+      .min(1)
+  })
+};
+
+export const exerciseTypes = Object.keys(exercisePayloads);
+
+export const exerciseSchema = z
+  .object({
+    id: z.string().regex(/^[a-z0-9-]+$/, 'exercise id must be kebab-case'),
+    type: z.enum(exerciseTypes),
+    srs: z.array(z.string()).default([]),
+    payload: z.unknown()
+  })
+  .superRefine((ex, ctx) => {
+    const result = exercisePayloads[ex.type].safeParse(ex.payload);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['payload', ...issue.path],
+          message: `${ex.type}: ${issue.message}`
+        });
+      }
+    }
+  });
+
+export const contentBlockSchema = z.object({
+  type: z.enum(['prose', 'table', 'example', 'callout']),
+  payload: z.record(z.unknown())
+});
+
+export const srsItemSchema = z.object({
+  id: z.string().regex(/^(vocab|grammar):[a-z0-9-]+$/),
+  payload: z.record(z.unknown())
+});
+
+export const lessonSchema = z.object({
+  id: z.string().regex(/^[a-z0-9-]+$/),
+  title: z.string().min(1),
+  version: z.number().int().positive(),
+  position: z.number().int().nonnegative(),
+  status: z.enum(['draft', 'reviewed', 'community_verified']).default('draft'),
+  objectives: z.array(z.string()).default([]),
+  prerequisites: z.array(z.string()).default([]),
+  skills: z.array(z.enum(['reading', 'writing', 'listening', 'speaking'])).default([]),
+  minutes: z.number().int().positive().optional(),
+  sources: z.array(z.string()).default([]),
+  provenance: z.record(z.string()).default({}),
+  blocks: z.array(contentBlockSchema).default([]),
+  srsItems: z.array(srsItemSchema).default([]),
+  exercises: z.array(exerciseSchema).default([])
+});
+
+export const moduleSchema = z.object({
+  id: z.string().regex(/^[a-z0-9-]+$/),
+  tier: z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  position: z.number().int().nonnegative()
+});

--- a/app/scripts/import-content.js
+++ b/app/scripts/import-content.js
@@ -1,0 +1,162 @@
+// Idempotent content importer: YAML in content/ -> Postgres.
+// Runs in the entrypoint after migrations (content ships inside the image),
+// and locally via `npm run content:import`. Single transaction: any
+// validation or drift error aborts the whole import.
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { parse } from 'yaml';
+import pg from 'pg';
+import { lessonSchema, moduleSchema, PAYLOAD_SCHEMA_VERSION } from './content-schema.mjs';
+
+const CONTENT_DIR = process.env.CONTENT_DIR ?? 'content';
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) throw new Error('DATABASE_URL is not set');
+
+function contentHash(obj) {
+  return createHash('sha256').update(JSON.stringify(obj)).digest('hex').slice(0, 16);
+}
+
+function loadYaml(path) {
+  try {
+    return parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    throw new Error(`${path}: ${e.message}`);
+  }
+}
+
+// ---- discover + validate everything before touching the DB ----
+const modules = [];
+const lessons = [];
+for (const tierDir of readdirSync(CONTENT_DIR).sort()) {
+  const tierPath = join(CONTENT_DIR, tierDir);
+  if (!statSync(tierPath).isDirectory()) continue;
+  for (const modDir of readdirSync(tierPath).sort()) {
+    const modPath = join(tierPath, modDir);
+    if (!statSync(modPath).isDirectory()) continue;
+    const modFile = join(modPath, '_module.yaml');
+    const mod = moduleSchema.parse(loadYaml(modFile));
+    if (mod.tier !== tierDir) throw new Error(`${modFile}: tier ${mod.tier} != directory ${tierDir}`);
+    modules.push(mod);
+    for (const f of readdirSync(modPath).sort()) {
+      if (!f.endsWith('.yaml') || f === '_module.yaml') continue;
+      const lessonFile = join(modPath, f);
+      const parsed = lessonSchema.safeParse(loadYaml(lessonFile));
+      if (!parsed.success) {
+        throw new Error(`${lessonFile}:\n${parsed.error.issues.map((i) => `  ${i.path.join('.')}: ${i.message}`).join('\n')}`);
+      }
+      lessons.push({ ...parsed.data, moduleId: mod.id, file: lessonFile });
+    }
+  }
+}
+
+const exerciseIds = new Set();
+for (const l of lessons)
+  for (const ex of l.exercises) {
+    const globalId = `${l.id}-${ex.id}`;
+    if (exerciseIds.has(globalId)) throw new Error(`duplicate exercise id ${globalId}`);
+    exerciseIds.add(globalId);
+  }
+
+// ---- import in one transaction ----
+const pool = new pg.Pool({ connectionString });
+const client = await pool.connect();
+try {
+  await client.query('BEGIN');
+
+  for (const m of modules) {
+    await client.query(
+      `INSERT INTO modules (id, tier, title, description, position)
+       VALUES ($1,$2,$3,$4,$5)
+       ON CONFLICT (id) DO UPDATE SET tier=$2, title=$3, description=$4, position=$5`,
+      [m.id, m.tier, m.title, m.description ?? null, m.position]
+    );
+  }
+
+  for (const l of lessons) {
+    const hash = contentHash({ blocks: l.blocks, exercises: l.exercises, srsItems: l.srsItems });
+    const existing = await client.query(
+      'SELECT content_version, provenance FROM lessons WHERE id=$1',
+      [l.id]
+    );
+    if (existing.rows.length > 0) {
+      const row = existing.rows[0];
+      const oldHash = row.provenance?.contentHash;
+      if (row.content_version === l.version && oldHash && oldHash !== hash) {
+        throw new Error(
+          `${l.file}: content changed but version still ${l.version} — bump 'version:' (drift guard)`
+        );
+      }
+    }
+    const provenance = { ...l.provenance, contentHash: hash };
+    await client.query(
+      `INSERT INTO lessons (id, module_id, position, title, objectives, prerequisites, skill_tags,
+                            status, content_version, sources, provenance, estimated_minutes)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+       ON CONFLICT (id) DO UPDATE SET module_id=$2, position=$3, title=$4, objectives=$5,
+         prerequisites=$6, skill_tags=$7, status=$8, content_version=$9, sources=$10,
+         provenance=$11, estimated_minutes=$12`,
+      [
+        l.id, l.moduleId, l.position, l.title,
+        JSON.stringify(l.objectives), JSON.stringify(l.prerequisites), JSON.stringify(l.skills),
+        l.status, l.version, JSON.stringify(l.sources), JSON.stringify(provenance),
+        l.minutes ?? null
+      ]
+    );
+
+    // Blocks are positional: replace wholesale for this lesson.
+    await client.query('DELETE FROM content_blocks WHERE lesson_id=$1', [l.id]);
+    for (let i = 0; i < l.blocks.length; i++) {
+      await client.query(
+        'INSERT INTO content_blocks (lesson_id, position, type, payload) VALUES ($1,$2,$3,$4)',
+        [l.id, i, l.blocks[i].type, JSON.stringify(l.blocks[i].payload)]
+      );
+    }
+
+    for (const s of l.srsItems) {
+      await client.query(
+        `INSERT INTO srs_items (id, kind, payload) VALUES ($1,$2,$3)
+         ON CONFLICT (id) DO UPDATE SET kind=$2, payload=$3`,
+        [s.id, s.id.split(':')[0], JSON.stringify(s.payload)]
+      );
+    }
+
+    for (let i = 0; i < l.exercises.length; i++) {
+      const ex = l.exercises[i];
+      const globalId = `${l.id}-${ex.id}`;
+      await client.query(
+        `INSERT INTO exercises (id, lesson_id, assessment_id, position, type,
+                                payload_schema_version, payload, content_version)
+         VALUES ($1,$2,NULL,$3,$4,$5,$6,$7)
+         ON CONFLICT (id) DO UPDATE SET lesson_id=$2, position=$3, type=$4,
+           payload_schema_version=$5, payload=$6, content_version=$7`,
+        [globalId, l.id, i, ex.type, PAYLOAD_SCHEMA_VERSION, JSON.stringify(ex.payload), l.version]
+      );
+      await client.query('DELETE FROM exercise_srs_items WHERE exercise_id=$1', [globalId]);
+      for (const srsId of ex.srs) {
+        await client.query(
+          'INSERT INTO exercise_srs_items (exercise_id, srs_item_id) VALUES ($1,$2)',
+          [globalId, srsId]
+        );
+      }
+    }
+  }
+
+  // Orphan check: DB rows whose IDs vanished from the repo (warn, never delete).
+  const repoLessonIds = lessons.map((l) => l.id);
+  const orphans = await client.query(
+    repoLessonIds.length > 0
+      ? { text: 'SELECT id FROM lessons WHERE NOT (id = ANY($1))', values: [repoLessonIds] }
+      : { text: 'SELECT id FROM lessons', values: [] }
+  );
+  for (const row of orphans.rows) console.warn(`WARN orphan lesson in DB not in repo: ${row.id}`);
+
+  await client.query('COMMIT');
+  console.log(`Content import OK: ${modules.length} modules, ${lessons.length} lessons, ${exerciseIds.size} exercises.`);
+} catch (e) {
+  await client.query('ROLLBACK');
+  throw e;
+} finally {
+  client.release();
+  await pool.end();
+}

--- a/app/src/lib/server/content/import.integration.test.ts
+++ b/app/src/lib/server/content/import.integration.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, cpSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getDb } from '$lib/server/db';
+import { sql } from 'drizzle-orm';
+
+function runImport(contentDir: string) {
+  return execFileSync('node', ['scripts/import-content.js'], {
+    env: { ...process.env, CONTENT_DIR: contentDir },
+    encoding: 'utf8'
+  });
+}
+
+async function snapshot() {
+  const db = getDb();
+  const rows = await db.execute(sql`
+    SELECT (SELECT count(*) FROM modules) AS modules,
+           (SELECT count(*) FROM lessons) AS lessons,
+           (SELECT count(*) FROM exercises) AS exercises,
+           (SELECT count(*) FROM content_blocks) AS blocks,
+           (SELECT count(*) FROM srs_items) AS srs,
+           (SELECT provenance->>'contentHash' FROM lessons WHERE id='a1-smoke-test') AS hash`);
+  return rows.rows[0];
+}
+
+// Requires DATABASE_URL pointing at a running, migrated Postgres.
+describe.skipIf(!process.env.DATABASE_URL)('content import', () => {
+  it('imports the repo content and is idempotent', async () => {
+    const out1 = runImport('content');
+    expect(out1).toContain('Content import OK');
+    const s1 = await snapshot();
+    expect(Number(s1.lessons)).toBeGreaterThanOrEqual(1);
+    expect(Number(s1.exercises)).toBeGreaterThanOrEqual(3);
+
+    const out2 = runImport('content');
+    expect(out2).toContain('Content import OK');
+    expect(await snapshot()).toEqual(s1);
+  });
+
+  it('rejects content changes without a version bump (drift guard)', async () => {
+    runImport('content');
+    const dir = mkdtempSync(join(tmpdir(), 'content-drift-'));
+    cpSync('content', dir, { recursive: true });
+    const lessonPath = join(dir, 'A1/foundation/smoke-test.yaml');
+    writeFileSync(lessonPath, readFileSync(lessonPath, 'utf8').replace('Hogy vagy?', 'Mi újság?'));
+    expect(() => runImport(dir)).toThrow(/drift guard|bump 'version:'/s);
+  });
+
+  it('rejects invalid exercise payloads with a useful error', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'content-invalid-'));
+    cpSync('content', dir, { recursive: true });
+    const lessonPath = join(dir, 'A1/foundation/smoke-test.yaml');
+    writeFileSync(
+      lessonPath,
+      readFileSync(lessonPath, 'utf8').replace('correctIndex: 0', 'correctIndex: notanumber')
+    );
+    expect(() => runImport(dir)).toThrow(/mcq/);
+  });
+});

--- a/app/src/lib/server/db/schema.ts
+++ b/app/src/lib/server/db/schema.ts
@@ -1,15 +1,24 @@
-import { pgTable, text, uuid, timestamp } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  pgEnum,
+  text,
+  uuid,
+  timestamp,
+  integer,
+  jsonb,
+  primaryKey
+} from 'drizzle-orm/pg-core';
 
 // Minimal table proving migrations run end-to-end.
-// Real domain tables arrive in later plans.
 export const appMeta = pgTable('app_meta', {
   key: text('key').primaryKey(),
   value: text('value').notNull()
 });
 
-// Accounts (SP1 Plan 2). Identity arrives via trusted X-Forwarded-User
-// header during the gated testing phase; rows are auto-provisioned on
-// first authenticated request. See plans/2026-07-05-sp1-plan2-auth.md.
+// ---------------------------------------------------------------------------
+// Accounts (SP1 Plan 2). Identity arrives via trusted X-Forwarded-User header
+// during the gated testing phase; rows auto-provision on first request.
+// ---------------------------------------------------------------------------
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   email: text('email').notNull().unique(),
@@ -18,3 +27,92 @@ export const users = pgTable('users', {
 });
 
 export type User = typeof users.$inferSelect;
+
+// ---------------------------------------------------------------------------
+// Tier-aware content model (SP1 Plan 3). Stable text IDs (author-chosen
+// slugs) everywhere so user progress survives re-imports; content_version
+// is author-managed and bumped on any content change (drift-guarded).
+// ---------------------------------------------------------------------------
+export const cefrTier = pgEnum('cefr_tier', ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']);
+export const lessonStatus = pgEnum('lesson_status', ['draft', 'reviewed', 'community_verified']);
+
+export const modules = pgTable('modules', {
+  id: text('id').primaryKey(),
+  tier: cefrTier('tier').notNull(),
+  title: text('title').notNull(),
+  description: text('description'),
+  position: integer('position').notNull()
+});
+
+export const lessons = pgTable('lessons', {
+  id: text('id').primaryKey(),
+  moduleId: text('module_id')
+    .notNull()
+    .references(() => modules.id),
+  position: integer('position').notNull(),
+  title: text('title').notNull(),
+  objectives: jsonb('objectives').$type<string[]>().notNull().default([]),
+  prerequisites: jsonb('prerequisites').$type<string[]>().notNull().default([]),
+  skillTags: jsonb('skill_tags').$type<string[]>().notNull().default([]),
+  status: lessonStatus('status').notNull().default('draft'),
+  contentVersion: integer('content_version').notNull().default(1),
+  sources: jsonb('sources').$type<string[]>().notNull().default([]),
+  provenance: jsonb('provenance').$type<Record<string, string>>().notNull().default({}),
+  estimatedMinutes: integer('estimated_minutes')
+});
+
+export const contentBlocks = pgTable(
+  'content_blocks',
+  {
+    lessonId: text('lesson_id')
+      .notNull()
+      .references(() => lessons.id),
+    position: integer('position').notNull(),
+    type: text('type').notNull(), // prose | table | example | callout
+    payload: jsonb('payload').notNull()
+  },
+  (t) => [primaryKey({ columns: [t.lessonId, t.position] })]
+);
+
+export const assessments = pgTable('assessments', {
+  id: text('id').primaryKey(),
+  tier: cefrTier('tier').notNull(),
+  title: text('title').notNull(),
+  description: text('description'),
+  position: integer('position').notNull().default(0)
+});
+
+// An exercise belongs to a lesson OR an assessment (exactly one set).
+export const exercises = pgTable('exercises', {
+  id: text('id').primaryKey(),
+  lessonId: text('lesson_id').references(() => lessons.id),
+  assessmentId: text('assessment_id').references(() => assessments.id),
+  position: integer('position').notNull(),
+  type: text('type').notNull(),
+  payloadSchemaVersion: integer('payload_schema_version').notNull().default(1),
+  payload: jsonb('payload').notNull(),
+  contentVersion: integer('content_version').notNull().default(1)
+});
+
+export const srsItems = pgTable('srs_items', {
+  id: text('id').primaryKey(),
+  kind: text('kind').notNull(), // vocab | grammar
+  payload: jsonb('payload').notNull()
+});
+
+export const exerciseSrsItems = pgTable(
+  'exercise_srs_items',
+  {
+    exerciseId: text('exercise_id')
+      .notNull()
+      .references(() => exercises.id),
+    srsItemId: text('srs_item_id')
+      .notNull()
+      .references(() => srsItems.id)
+  },
+  (t) => [primaryKey({ columns: [t.exerciseId, t.srsItemId] })]
+);
+
+export type Lesson = typeof lessons.$inferSelect;
+export type Module = typeof modules.$inferSelect;
+export type Exercise = typeof exercises.$inferSelect;

--- a/app/src/routes/learn/+page.server.ts
+++ b/app/src/routes/learn/+page.server.ts
@@ -1,0 +1,38 @@
+import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db';
+import { modules, lessons } from '$lib/server/db/schema';
+import { asc } from 'drizzle-orm';
+
+export const load: PageServerLoad = async () => {
+  const db = getDb();
+  const mods = await db.select().from(modules).orderBy(asc(modules.tier), asc(modules.position));
+  const less = await db
+    .select({
+      id: lessons.id,
+      moduleId: lessons.moduleId,
+      title: lessons.title,
+      position: lessons.position,
+      status: lessons.status,
+      estimatedMinutes: lessons.estimatedMinutes
+    })
+    .from(lessons)
+    .orderBy(asc(lessons.position));
+
+  // Group: tier -> modules -> lessons. Tiers with no modules simply don't
+  // appear (C1/C2 stay invisible until content exists).
+  const tiers: { tier: string; modules: { id: string; title: string; description: string | null; lessons: typeof less }[] }[] = [];
+  for (const m of mods) {
+    let tier = tiers.find((t) => t.tier === m.tier);
+    if (!tier) {
+      tier = { tier: m.tier, modules: [] };
+      tiers.push(tier);
+    }
+    tier.modules.push({
+      id: m.id,
+      title: m.title,
+      description: m.description,
+      lessons: less.filter((l) => l.moduleId === m.id)
+    });
+  }
+  return { tiers };
+};

--- a/app/src/routes/learn/+page.svelte
+++ b/app/src/routes/learn/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  let { data } = $props();
+  const statusLabel: Record<string, { text: string; cls: string }> = {
+    draft: { text: 'draft', cls: 'bg-amber-100 text-amber-800' },
+    reviewed: { text: 'AI-drafted, provisional', cls: 'bg-sky-100 text-sky-800' },
+    community_verified: { text: 'community-verified', cls: 'bg-emerald-100 text-emerald-800' }
+  };
+</script>
+
+<main class="mx-auto max-w-3xl p-8">
+  <a href="/" class="text-sm text-teal-700 hover:underline">&larr; Home</a>
+  <h1 class="mt-2 text-2xl font-bold text-teal-700">Curriculum</h1>
+  <p class="mt-1 text-slate-600">Zero to B2, one tier at a time.</p>
+
+  {#each data.tiers as tier}
+    <section class="mt-8">
+      <h2 class="text-xl font-bold text-slate-700">{tier.tier}</h2>
+      {#each tier.modules as mod}
+        <div class="mt-4 rounded-xl bg-white p-6 shadow-md">
+          <h3 class="text-lg font-semibold text-slate-700">{mod.title}</h3>
+          {#if mod.description}<p class="mt-1 text-sm text-slate-600">{mod.description}</p>{/if}
+          <ul class="mt-3 divide-y divide-slate-100">
+            {#each mod.lessons as lesson}
+              <li class="flex items-center justify-between py-2">
+                <a href="/learn/{lesson.id}" class="text-teal-700 hover:underline">{lesson.title}</a>
+                <span class="rounded-full px-2 py-0.5 text-xs {statusLabel[lesson.status].cls}"
+                  >{statusLabel[lesson.status].text}</span
+                >
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/each}
+    </section>
+  {:else}
+    <p class="mt-8 text-slate-500">No content imported yet.</p>
+  {/each}
+</main>

--- a/docs/superpowers/plans/2026-07-05-sp1-plan3-content.md
+++ b/docs/superpowers/plans/2026-07-05-sp1-plan3-content.md
@@ -1,0 +1,36 @@
+# SP1 Plan 3 — Tier-Aware Content Model & Import
+
+**Goal:** The spec §4 content scaffold: `tier → module → lesson → {blocks, exercises}` (+ per-tier assessments), authored as YAML in-repo, imported idempotently into Postgres. Content ships **inside the image** (COPY at build; import runs in the entrypoint after migrate) so a deploy is atomic: code + schema + content move together.
+
+## Schema (Drizzle; stable text IDs everywhere)
+
+- `cefr_tier` pg enum: A1 A2 B1 B2 C1 C2 (enum-extensible; C1/C2 never seeded into nav)
+- `modules(id text pk, tier, title, description, position)`
+- `lessons(id text pk, module_id fk, position, title, objectives jsonb, prerequisites jsonb, skill_tags jsonb, status: draft|reviewed|community_verified, content_version int, sources jsonb, provenance jsonb, estimated_minutes)`
+- `content_blocks(lesson_id fk, position, type: prose|table|example|callout, payload jsonb, pk(lesson_id, position))`
+- `exercises(id text pk, lesson_id fk nullable, assessment_id fk nullable, position, type text, payload_schema_version int, payload jsonb, content_version int)` — belongs to a lesson OR an assessment
+- `assessments(id text pk, tier, title, description, position)`
+- `srs_items(id text pk, kind: vocab|grammar, payload jsonb)` + `exercise_srs_items(exercise_id, srs_item_id, pk both)`
+
+## Content format
+
+`app/content/<tier>/<module-dir>/<lesson>.yaml` + `app/content/<tier>/assessment.yaml`, validated by zod schemas in `$lib/content/schema.ts` (shared with the Plan 4 engine — payloads are type-discriminated and versioned). Author-managed `version:` per lesson; changing content without bumping version fails the import (drift guard).
+
+## Import (`app/scripts/import-content.js` → `npm run content:import`)
+
+- Parse + zod-validate all YAML; fail loudly on any error (no partial imports: single transaction).
+- Upsert by stable ID; deletions in repo → **orphan warning, not delete** (progress safety; deprecation policy hardens later).
+- Idempotent: re-running with unchanged content is a no-op (tested).
+- Entrypoint: `migrate → import → serve`.
+
+## Tasks
+1. Schema + migration + zod content schemas (unit-tested validation)
+2. Importer + sample smoke-test lesson (tiny, marked draft) + idempotency tests against dev PG
+3. Entrypoint/image wiring + curriculum index page (`/learn`) rendering tiers→modules→lessons from DB
+4. Deploy + verify
+
+## DoD
+- [ ] Migration applies; import of sample content idempotent (run twice = same row state)
+- [ ] Invalid YAML/payload fails import with a useful error; version-drift guard works
+- [ ] `/learn` lists the imported curriculum behind the gate
+- [ ] Live on magyarul.nyolc.cc


### PR DESCRIPTION
Plan 3. Schema: modules/lessons/content_blocks/exercises/assessments/
srs_items with stable text IDs, cefr_tier enum, versioned JSONB
payloads. Zod content schemas shared between the plain-JS importer and
the app. Importer: single-transaction, idempotent upserts by stable ID,
version-drift guard, orphan warnings (never deletes). Content ships in
the image; entrypoint = migrate -> import -> serve. /learn renders
tiers->modules->lessons with honest status badges. Unit 13/13
(incl. idempotency + drift-guard + invalid-payload), e2e 6/6.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
