### PR TITLE
feat: SP1 Plan 5 - progress tracking + SM-2 SRS

### DIFF
--- a/app/drizzle/0003_careless_lilandra.sql
+++ b/app/drizzle/0003_careless_lilandra.sql
@@ -1,0 +1,70 @@
+CREATE TYPE "public"."answer_class" AS ENUM('correct', 'accent', 'wrong');--> statement-breakpoint
+CREATE TYPE "public"."lesson_progress_status" AS ENUM('in_progress', 'completed');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "exercise_progress" (
+	"user_id" uuid NOT NULL,
+	"exercise_id" text NOT NULL,
+	"first_result" "answer_class" NOT NULL,
+	"best_result" "answer_class" NOT NULL,
+	"attempts" integer DEFAULT 1 NOT NULL,
+	"last_attempt_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "exercise_progress_user_id_exercise_id_pk" PRIMARY KEY("user_id","exercise_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "lesson_progress" (
+	"user_id" uuid NOT NULL,
+	"lesson_id" text NOT NULL,
+	"status" "lesson_progress_status" DEFAULT 'in_progress' NOT NULL,
+	"first_accuracy" real,
+	"last_visited_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "lesson_progress_user_id_lesson_id_pk" PRIMARY KEY("user_id","lesson_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_srs_state" (
+	"user_id" uuid NOT NULL,
+	"srs_item_id" text NOT NULL,
+	"skill" text NOT NULL,
+	"modality" text NOT NULL,
+	"direction" text NOT NULL,
+	"ease" real DEFAULT 2.5 NOT NULL,
+	"interval_days" real DEFAULT 0 NOT NULL,
+	"due_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"reps" integer DEFAULT 0 NOT NULL,
+	"lapses" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "user_srs_state_user_id_srs_item_id_skill_modality_direction_pk" PRIMARY KEY("user_id","srs_item_id","skill","modality","direction")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "exercise_progress" ADD CONSTRAINT "exercise_progress_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "exercise_progress" ADD CONSTRAINT "exercise_progress_exercise_id_exercises_id_fk" FOREIGN KEY ("exercise_id") REFERENCES "public"."exercises"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lesson_progress" ADD CONSTRAINT "lesson_progress_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lesson_progress" ADD CONSTRAINT "lesson_progress_lesson_id_lessons_id_fk" FOREIGN KEY ("lesson_id") REFERENCES "public"."lessons"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_srs_state" ADD CONSTRAINT "user_srs_state_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_srs_state" ADD CONSTRAINT "user_srs_state_srs_item_id_srs_items_id_fk" FOREIGN KEY ("srs_item_id") REFERENCES "public"."srs_items"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/app/drizzle/meta/0003_snapshot.json
+++ b/app/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,851 @@
+{
+  "id": "88a78a26-cfe4-4b54-828e-efbc63d5745e",
+  "prevId": "ee5a058b-7d78-4d0e-879e-7f1116e05345",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_meta": {
+      "name": "app_meta",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assessments": {
+      "name": "assessments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "cefr_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_blocks": {
+      "name": "content_blocks",
+      "schema": "",
+      "columns": {
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_blocks_lesson_id_lessons_id_fk": {
+          "name": "content_blocks_lesson_id_lessons_id_fk",
+          "tableFrom": "content_blocks",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "content_blocks_lesson_id_position_pk": {
+          "name": "content_blocks_lesson_id_position_pk",
+          "columns": [
+            "lesson_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_progress": {
+      "name": "exercise_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_result": {
+          "name": "first_result",
+          "type": "answer_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "best_result": {
+          "name": "best_result",
+          "type": "answer_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_progress_user_id_users_id_fk": {
+          "name": "exercise_progress_user_id_users_id_fk",
+          "tableFrom": "exercise_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercise_progress_exercise_id_exercises_id_fk": {
+          "name": "exercise_progress_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_progress",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exercise_progress_user_id_exercise_id_pk": {
+          "name": "exercise_progress_user_id_exercise_id_pk",
+          "columns": [
+            "user_id",
+            "exercise_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_srs_items": {
+      "name": "exercise_srs_items",
+      "schema": "",
+      "columns": {
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "srs_item_id": {
+          "name": "srs_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_srs_items_exercise_id_exercises_id_fk": {
+          "name": "exercise_srs_items_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_srs_items",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exercise_srs_items_srs_item_id_srs_items_id_fk": {
+          "name": "exercise_srs_items_srs_item_id_srs_items_id_fk",
+          "tableFrom": "exercise_srs_items",
+          "tableTo": "srs_items",
+          "columnsFrom": [
+            "srs_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "exercise_srs_items_exercise_id_srs_item_id_pk": {
+          "name": "exercise_srs_items_exercise_id_srs_item_id_pk",
+          "columns": [
+            "exercise_id",
+            "srs_item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_schema_version": {
+          "name": "payload_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_version": {
+          "name": "content_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercises_lesson_id_lessons_id_fk": {
+          "name": "exercises_lesson_id_lessons_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exercises_assessment_id_assessments_id_fk": {
+          "name": "exercises_assessment_id_assessments_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "assessments",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lesson_progress": {
+      "name": "lesson_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "lesson_progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "first_accuracy": {
+          "name": "first_accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visited_at": {
+          "name": "last_visited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lesson_progress_user_id_users_id_fk": {
+          "name": "lesson_progress_user_id_users_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lesson_progress_user_id_lesson_id_pk": {
+          "name": "lesson_progress_user_id_lesson_id_pk",
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skill_tags": {
+          "name": "skill_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "lesson_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "content_version": {
+          "name": "content_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "cefr_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.srs_items": {
+      "name": "srs_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_srs_state": {
+      "name": "user_srs_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "srs_item_id": {
+          "name": "srs_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill": {
+          "name": "skill",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ease": {
+          "name": "ease",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2.5
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lapses": {
+          "name": "lapses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_srs_state_user_id_users_id_fk": {
+          "name": "user_srs_state_user_id_users_id_fk",
+          "tableFrom": "user_srs_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_srs_state_srs_item_id_srs_items_id_fk": {
+          "name": "user_srs_state_srs_item_id_srs_items_id_fk",
+          "tableFrom": "user_srs_state",
+          "tableTo": "srs_items",
+          "columnsFrom": [
+            "srs_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_srs_state_user_id_srs_item_id_skill_modality_direction_pk": {
+          "name": "user_srs_state_user_id_srs_item_id_skill_modality_direction_pk",
+          "columns": [
+            "user_id",
+            "srs_item_id",
+            "skill",
+            "modality",
+            "direction"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.answer_class": {
+      "name": "answer_class",
+      "schema": "public",
+      "values": [
+        "correct",
+        "accent",
+        "wrong"
+      ]
+    },
+    "public.cefr_tier": {
+      "name": "cefr_tier",
+      "schema": "public",
+      "values": [
+        "A1",
+        "A2",
+        "B1",
+        "B2",
+        "C1",
+        "C2"
+      ]
+    },
+    "public.lesson_progress_status": {
+      "name": "lesson_progress_status",
+      "schema": "public",
+      "values": [
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.lesson_status": {
+      "name": "lesson_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "reviewed",
+        "community_verified"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/meta/_journal.json
+++ b/app/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783275846191,
       "tag": "0002_messy_leopardon",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1783276440185,
+      "tag": "0003_careless_lilandra",
+      "breakpoints": true
     }
   ]
 }

--- a/app/e2e/progress.spec.ts
+++ b/app/e2e/progress.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// One user across the whole file; steps build on each other.
+test.describe.configure({ mode: 'serial' });
+test.use({ extraHTTPHeaders: { 'X-Forwarded-User': 'e2e-progress@example.com' } });
+
+test('attempt in the browser records progress on /learn', async ({ page }) => {
+  await page.goto('/learn/a1-smoke-test');
+  const ex = page.locator('[data-exercise-id="a1-smoke-test-ex1"]');
+  const post = page.waitForResponse((r) => r.url().includes('/api/attempts') && r.ok());
+  await ex.getByLabel('answer').fill('szia');
+  await ex.getByRole('button', { name: 'Check' }).click();
+  await post;
+
+  await page.goto('/learn');
+  await expect(page.getByTitle('in progress')).toBeVisible();
+});
+
+test('completing every exercise marks the lesson completed', async ({ request, page }) => {
+  for (const ex of ['ex2', 'ex3', 'ex4', 'ex5', 'ex6', 'ex7']) {
+    const res = await request.post('/api/attempts', {
+      data: { exerciseId: `a1-smoke-test-${ex}`, result: 'correct' }
+    });
+    expect(res.ok()).toBeTruthy();
+  }
+  await page.goto('/learn');
+  await expect(page.getByTitle('completed')).toBeVisible();
+});
+
+test('review shows due items and grades them', async ({ request, page }) => {
+  // A wrong answer makes its SRS item due immediately.
+  await request.post('/api/attempts', {
+    data: { exerciseId: 'a1-smoke-test-ex1', result: 'wrong' }
+  });
+  await page.goto('/review');
+  await page.getByLabel('flip review card').click();
+  await page.getByRole('button', { name: 'Knew it' }).click();
+  await expect(page.getByTestId('review-done')).toBeVisible();
+});
+
+test('export includes progress and srs sections', async ({ request }) => {
+  const body = await (await request.get('/account/export')).json();
+  expect(body.lessonProgress.length).toBeGreaterThanOrEqual(1);
+  expect(body.exerciseProgress.length).toBeGreaterThanOrEqual(7);
+  expect(body.srs.length).toBeGreaterThanOrEqual(1);
+});

--- a/app/src/lib/engine/sm2.test.ts
+++ b/app/src/lib/engine/sm2.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { sm2, qualityFor, INITIAL_SRS, nextDue } from './sm2';
+
+describe('qualityFor', () => {
+  it('maps answer classes', () => {
+    expect(qualityFor('correct')).toBe(5);
+    expect(qualityFor('correct', true)).toBe(4); // self-graded card flip
+    expect(qualityFor('accent')).toBe(3);
+    expect(qualityFor('wrong')).toBe(1);
+  });
+});
+
+describe('sm2', () => {
+  it('first success schedules 1 day, second 6 days', () => {
+    const s1 = sm2(INITIAL_SRS, 5);
+    expect(s1.intervalDays).toBe(1);
+    expect(s1.reps).toBe(1);
+    const s2 = sm2(s1, 5);
+    expect(s2.intervalDays).toBe(6);
+  });
+
+  it('repeated success grows the interval multiplicatively', () => {
+    let s = sm2(sm2(INITIAL_SRS, 5), 5); // 6 days
+    const s3 = sm2(s, 5);
+    expect(s3.intervalDays).toBeGreaterThan(6 * 2); // ease ~2.6
+  });
+
+  it('failure resets reps and interval, counts a lapse, drops ease', () => {
+    const grown = sm2(sm2(INITIAL_SRS, 5), 5);
+    const failed = sm2(grown, 1);
+    expect(failed.intervalDays).toBe(0);
+    expect(failed.reps).toBe(0);
+    expect(failed.lapses).toBe(1);
+    expect(failed.ease).toBeLessThan(grown.ease);
+  });
+
+  it('ease never drops below 1.3', () => {
+    let s = INITIAL_SRS;
+    for (let i = 0; i < 20; i++) s = sm2(s, 0);
+    expect(s.ease).toBe(1.3);
+  });
+
+  it('accent-quality (3) succeeds but slows ease growth', () => {
+    const s = sm2(INITIAL_SRS, 3);
+    expect(s.reps).toBe(1);
+    expect(s.ease).toBeLessThan(2.5);
+  });
+
+  it('nextDue adds interval days', () => {
+    const from = new Date('2026-07-05T00:00:00Z');
+    expect(nextDue(from, 6).toISOString()).toBe('2026-07-11T00:00:00.000Z');
+  });
+});

--- a/app/src/lib/engine/sm2.ts
+++ b/app/src/lib/engine/sm2.ts
@@ -1,0 +1,40 @@
+/**
+ * SM-2 spaced-repetition scheduler (pure). Quality 0-5; below 3 is a lapse.
+ * Answer-class mapping lives beside it so the whole pipeline is testable.
+ */
+import type { AnswerClass } from './validate';
+
+export interface SrsState {
+  ease: number; // ease factor, floor 1.3
+  intervalDays: number;
+  reps: number; // consecutive successful reviews
+  lapses: number;
+}
+
+export const INITIAL_SRS: SrsState = { ease: 2.5, intervalDays: 0, reps: 0, lapses: 0 };
+
+export function qualityFor(result: AnswerClass, selfGraded = false): number {
+  if (result === 'correct') return selfGraded ? 4 : 5;
+  if (result === 'accent') return 3;
+  return 1;
+}
+
+export function sm2(prev: SrsState, quality: number): SrsState {
+  const q = Math.max(0, Math.min(5, quality));
+  if (q < 3) {
+    return {
+      ease: Math.max(1.3, prev.ease - 0.2),
+      intervalDays: 0, // due again now (relearn)
+      reps: 0,
+      lapses: prev.lapses + 1
+    };
+  }
+  const ease = Math.max(1.3, prev.ease + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02)));
+  const reps = prev.reps + 1;
+  const intervalDays = reps === 1 ? 1 : reps === 2 ? 6 : Math.round(prev.intervalDays * ease * 10) / 10;
+  return { ease, intervalDays, reps, lapses: prev.lapses };
+}
+
+export function nextDue(from: Date, intervalDays: number): Date {
+  return new Date(from.getTime() + intervalDays * 24 * 60 * 60 * 1000);
+}

--- a/app/src/lib/server/db/schema.ts
+++ b/app/src/lib/server/db/schema.ts
@@ -5,6 +5,7 @@ import {
   uuid,
   timestamp,
   integer,
+  real,
   jsonb,
   primaryKey
 } from 'drizzle-orm/pg-core';
@@ -116,3 +117,64 @@ export const exerciseSrsItems = pgTable(
 export type Lesson = typeof lessons.$inferSelect;
 export type Module = typeof modules.$inferSelect;
 export type Exercise = typeof exercises.$inferSelect;
+
+// ---------------------------------------------------------------------------
+// Progress & SRS (SP1 Plan 5). All user FKs cascade on delete so the GDPR
+// account-delete stays a single statement.
+// ---------------------------------------------------------------------------
+export const answerClass = pgEnum('answer_class', ['correct', 'accent', 'wrong']);
+export const lessonProgressStatus = pgEnum('lesson_progress_status', ['in_progress', 'completed']);
+
+export const exerciseProgress = pgTable(
+  'exercise_progress',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    exerciseId: text('exercise_id')
+      .notNull()
+      .references(() => exercises.id),
+    firstResult: answerClass('first_result').notNull(),
+    bestResult: answerClass('best_result').notNull(),
+    attempts: integer('attempts').notNull().default(1),
+    lastAttemptAt: timestamp('last_attempt_at', { withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.exerciseId] })]
+);
+
+export const lessonProgress = pgTable(
+  'lesson_progress',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    lessonId: text('lesson_id')
+      .notNull()
+      .references(() => lessons.id),
+    status: lessonProgressStatus('status').notNull().default('in_progress'),
+    firstAccuracy: real('first_accuracy'),
+    lastVisitedAt: timestamp('last_visited_at', { withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.lessonId] })]
+);
+
+export const userSrsState = pgTable(
+  'user_srs_state',
+  {
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    srsItemId: text('srs_item_id')
+      .notNull()
+      .references(() => srsItems.id),
+    skill: text('skill').notNull(), // reading | writing | listening | speaking
+    modality: text('modality').notNull(), // text | audio (SP3)
+    direction: text('direction').notNull(), // recognition | production
+    ease: real('ease').notNull().default(2.5),
+    intervalDays: real('interval_days').notNull().default(0),
+    dueAt: timestamp('due_at', { withTimezone: true }).notNull().defaultNow(),
+    reps: integer('reps').notNull().default(0),
+    lapses: integer('lapses').notNull().default(0)
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.srsItemId, t.skill, t.modality, t.direction] })]
+);

--- a/app/src/lib/server/progress/record-attempt.integration.test.ts
+++ b/app/src/lib/server/progress/record-attempt.integration.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { recordAttempt } from './record-attempt';
+import { getOrCreateUserByEmail, deleteUserById } from '$lib/server/auth/user-repo';
+import { getDb } from '$lib/server/db';
+import { sql } from 'drizzle-orm';
+
+// Requires DATABASE_URL pointing at a running, migrated Postgres.
+describe.skipIf(!process.env.DATABASE_URL)('recordAttempt', () => {
+  let userId: string;
+
+  beforeAll(async () => {
+    execFileSync('node', ['scripts/import-content.js'], { env: { ...process.env, CONTENT_DIR: 'content' } });
+    const user = await getOrCreateUserByEmail(`progress-${Date.now()}@example.com`);
+    userId = user.id;
+  });
+
+  it('records first attempt immutably and aggregates best/attempts', async () => {
+    await recordAttempt(userId, 'a1-smoke-test-ex1', 'wrong');
+    await recordAttempt(userId, 'a1-smoke-test-ex1', 'correct');
+    const row = (
+      await getDb().execute(
+        sql`SELECT first_result, best_result, attempts FROM exercise_progress
+            WHERE user_id=${userId} AND exercise_id='a1-smoke-test-ex1'`
+      )
+    ).rows[0];
+    expect(row.first_result).toBe('wrong'); // immutable
+    expect(row.best_result).toBe('correct');
+    expect(Number(row.attempts)).toBe(2);
+  });
+
+  it('marks the lesson completed once every exercise is attempted', async () => {
+    for (const ex of ['ex2', 'ex3', 'ex4', 'ex5', 'ex6', 'ex7']) {
+      await recordAttempt(userId, `a1-smoke-test-${ex}`, 'correct');
+    }
+    const row = (
+      await getDb().execute(
+        sql`SELECT status, first_accuracy FROM lesson_progress
+            WHERE user_id=${userId} AND lesson_id='a1-smoke-test'`
+      )
+    ).rows[0];
+    expect(row.status).toBe('completed');
+    // 6 of 7 first attempts correct (ex1 was wrong first)
+    expect(Number(row.first_accuracy)).toBeCloseTo(6 / 7, 5);
+  });
+
+  it('advances SRS state for linked items (production direction)', async () => {
+    const rows = (
+      await getDb().execute(
+        sql`SELECT direction, reps, interval_days FROM user_srs_state
+            WHERE user_id=${userId} AND srs_item_id='vocab:szia'`
+      )
+    ).rows;
+    expect(rows.length).toBeGreaterThanOrEqual(2); // production (ex1) + recognition (ex3 card)
+    const production = rows.find((r) => r.direction === 'production');
+    expect(Number(production!.reps)).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GDPR cascade: deleting the user removes all progress', async () => {
+    await deleteUserById(userId);
+    const counts = (
+      await getDb().execute(
+        sql`SELECT (SELECT count(*) FROM exercise_progress WHERE user_id=${userId})
+              + (SELECT count(*) FROM lesson_progress WHERE user_id=${userId})
+              + (SELECT count(*) FROM user_srs_state WHERE user_id=${userId}) AS total`
+      )
+    ).rows[0];
+    expect(Number(counts.total)).toBe(0);
+  });
+});

--- a/app/src/lib/server/progress/record-attempt.ts
+++ b/app/src/lib/server/progress/record-attempt.ts
@@ -1,0 +1,148 @@
+import { getDb } from '$lib/server/db';
+import {
+  exercises,
+  exerciseProgress,
+  lessonProgress,
+  exerciseSrsItems,
+  lessons,
+  userSrsState
+} from '$lib/server/db/schema';
+import { eq, and, sql } from 'drizzle-orm';
+import type { AnswerClass } from '$lib/engine/validate';
+import { sm2, qualityFor, nextDue, type SrsState } from '$lib/engine/sm2';
+
+const RANK: Record<AnswerClass, number> = { wrong: 0, accent: 1, correct: 2 };
+
+/**
+ * Record one attempt: aggregate exercise progress (first_result immutable),
+ * recompute lesson completion, and advance SM-2 state for linked SRS items.
+ */
+export async function recordAttempt(userId: string, exerciseId: string, result: AnswerClass) {
+  const db = getDb();
+  const ex = (await db.select().from(exercises).where(eq(exercises.id, exerciseId)))[0];
+  if (!ex || !ex.lessonId) throw new Error(`unknown exercise ${exerciseId}`);
+
+  await db.transaction(async (tx) => {
+    // -- exercise aggregate --------------------------------------------------
+    const existing = (
+      await tx
+        .select()
+        .from(exerciseProgress)
+        .where(and(eq(exerciseProgress.userId, userId), eq(exerciseProgress.exerciseId, exerciseId)))
+    )[0];
+    if (existing) {
+      const best = RANK[result] > RANK[existing.bestResult] ? result : existing.bestResult;
+      await tx
+        .update(exerciseProgress)
+        .set({ bestResult: best, attempts: existing.attempts + 1, lastAttemptAt: new Date() })
+        .where(and(eq(exerciseProgress.userId, userId), eq(exerciseProgress.exerciseId, exerciseId)));
+    } else {
+      await tx.insert(exerciseProgress).values({
+        userId,
+        exerciseId,
+        firstResult: result,
+        bestResult: result
+      });
+    }
+
+    // -- lesson recompute ----------------------------------------------------
+    const lessonExercises = await tx
+      .select({ id: exercises.id })
+      .from(exercises)
+      .where(eq(exercises.lessonId, ex.lessonId!));
+    const attempted = await tx
+      .select({ id: exerciseProgress.exerciseId, first: exerciseProgress.firstResult })
+      .from(exerciseProgress)
+      .innerJoin(exercises, eq(exercises.id, exerciseProgress.exerciseId))
+      .where(and(eq(exerciseProgress.userId, userId), eq(exercises.lessonId, ex.lessonId!)));
+    const complete = attempted.length >= lessonExercises.length;
+    const firstAccuracy =
+      attempted.length > 0 ? attempted.filter((a) => a.first === 'correct').length / attempted.length : null;
+
+    await tx
+      .insert(lessonProgress)
+      .values({
+        userId,
+        lessonId: ex.lessonId!,
+        status: complete ? 'completed' : 'in_progress',
+        firstAccuracy,
+        lastVisitedAt: new Date()
+      })
+      .onConflictDoUpdate({
+        target: [lessonProgress.userId, lessonProgress.lessonId],
+        set: {
+          status: complete ? 'completed' : 'in_progress',
+          firstAccuracy,
+          lastVisitedAt: new Date()
+        }
+      });
+
+    // -- SRS advance -----------------------------------------------------------
+    const lesson = (await tx.select().from(lessons).where(eq(lessons.id, ex.lessonId!)))[0];
+    const skill = lesson.skillTags[0] ?? 'reading';
+    const modality = 'text';
+    const direction = ex.type === 'card_flip' ? 'recognition' : 'production';
+    const quality = qualityFor(result, ex.type === 'card_flip');
+
+    const linked = await tx
+      .select({ srsItemId: exerciseSrsItems.srsItemId })
+      .from(exerciseSrsItems)
+      .where(eq(exerciseSrsItems.exerciseId, exerciseId));
+
+    for (const { srsItemId } of linked) {
+      const key = and(
+        eq(userSrsState.userId, userId),
+        eq(userSrsState.srsItemId, srsItemId),
+        eq(userSrsState.skill, skill),
+        eq(userSrsState.modality, modality),
+        eq(userSrsState.direction, direction)
+      );
+      const prevRow = (await tx.select().from(userSrsState).where(key))[0];
+      const prev: SrsState = prevRow
+        ? { ease: prevRow.ease, intervalDays: prevRow.intervalDays, reps: prevRow.reps, lapses: prevRow.lapses }
+        : { ease: 2.5, intervalDays: 0, reps: 0, lapses: 0 };
+      const next = sm2(prev, quality);
+      const due = nextDue(new Date(), next.intervalDays);
+      if (prevRow) {
+        await tx
+          .update(userSrsState)
+          .set({ ease: next.ease, intervalDays: next.intervalDays, reps: next.reps, lapses: next.lapses, dueAt: due })
+          .where(key);
+      } else {
+        await tx.insert(userSrsState).values({
+          userId,
+          srsItemId,
+          skill,
+          modality,
+          direction,
+          ease: next.ease,
+          intervalDays: next.intervalDays,
+          reps: next.reps,
+          lapses: next.lapses,
+          dueAt: due
+        });
+      }
+    }
+  });
+}
+
+/** Touch last-visited (lesson page load). */
+export async function touchLesson(userId: string, lessonId: string) {
+  const db = getDb();
+  await db
+    .insert(lessonProgress)
+    .values({ userId, lessonId, lastVisitedAt: new Date() })
+    .onConflictDoUpdate({
+      target: [lessonProgress.userId, lessonProgress.lessonId],
+      set: { lastVisitedAt: new Date() }
+    });
+}
+
+export async function dueSrsItems(userId: string) {
+  const db = getDb();
+  return db.execute(sql`
+    SELECT s.user_id, s.srs_item_id, s.skill, s.modality, s.direction, i.payload
+    FROM user_srs_state s JOIN srs_items i ON i.id = s.srs_item_id
+    WHERE s.user_id = ${userId} AND s.due_at <= now()
+    ORDER BY s.due_at ASC LIMIT 20`);
+}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -4,9 +4,15 @@
 
 <main class="mx-auto max-w-3xl p-8">
   <h1 class="text-2xl font-bold text-teal-700">Learning Hungarian</h1>
-  <p class="mt-2 text-slate-600">Platform foundation is running.</p>
+  <p class="mt-2 text-slate-600">Zero to B2 — magyarul.</p>
+
+  <nav class="mt-6 flex gap-3">
+    <a href="/learn" class="rounded-md bg-teal-700 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-800">Curriculum</a>
+    <a href="/review" class="rounded-md border border-teal-700 px-4 py-2 text-sm font-semibold text-teal-700 hover:bg-teal-50">Review</a>
+  </nav>
+
   {#if data.user}
-    <p class="mt-4 text-sm text-slate-600">
+    <p class="mt-6 text-sm text-slate-600">
       Signed in as <span class="font-semibold">{data.user.email}</span> ·
       <a href="/account" class="text-teal-700 hover:underline">Your account</a>
     </p>

--- a/app/src/routes/account/export/+server.ts
+++ b/app/src/routes/account/export/+server.ts
@@ -1,16 +1,29 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { getDb } from '$lib/server/db';
+import { exerciseProgress, lessonProgress, userSrsState } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
 
 /**
  * GDPR data portability: everything we hold about the requesting user,
- * as a JSON download. Later plans (progress, SRS, feedback) append their
- * sections here — this endpoint is THE canonical exporter.
+ * as a JSON download. Later plans (feedback) append their sections here —
+ * this endpoint is THE canonical exporter.
  */
 export const GET: RequestHandler = async ({ locals }) => {
   if (!locals.user) throw error(401, 'Not signed in');
+  const db = getDb();
   const body = {
     exportedAt: new Date().toISOString(),
-    user: locals.user
+    user: locals.user,
+    lessonProgress: await db
+      .select()
+      .from(lessonProgress)
+      .where(eq(lessonProgress.userId, locals.user.id)),
+    exerciseProgress: await db
+      .select()
+      .from(exerciseProgress)
+      .where(eq(exerciseProgress.userId, locals.user.id)),
+    srs: await db.select().from(userSrsState).where(eq(userSrsState.userId, locals.user.id))
   };
   return json(body, {
     headers: { 'Content-Disposition': 'attachment; filename="my-data-magyarul-nyolc-cc.json"' }

--- a/app/src/routes/api/attempts/+server.ts
+++ b/app/src/routes/api/attempts/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { recordAttempt } from '$lib/server/progress/record-attempt';
+
+const VALID = new Set(['correct', 'accent', 'wrong']);
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+  if (!locals.user) throw error(401, 'Not signed in');
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.exerciseId !== 'string' || !VALID.has(body.result)) {
+    throw error(400, 'expected { exerciseId: string, result: correct|accent|wrong }');
+  }
+  await recordAttempt(locals.user.id, body.exerciseId, body.result);
+  return json({ ok: true });
+};

--- a/app/src/routes/api/review/+server.ts
+++ b/app/src/routes/api/review/+server.ts
@@ -1,0 +1,38 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getDb } from '$lib/server/db';
+import { userSrsState } from '$lib/server/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { sm2, qualityFor, nextDue, type SrsState } from '$lib/engine/sm2';
+
+/** Grade a due SRS item from the review session (self-graded card). */
+export const POST: RequestHandler = async ({ locals, request }) => {
+  if (!locals.user) throw error(401, 'Not signed in');
+  const body = await request.json().catch(() => null);
+  if (!body?.srsItemId || !['correct', 'wrong'].includes(body.result)) {
+    throw error(400, 'expected { srsItemId, skill, direction, result }');
+  }
+  const db = getDb();
+  const key = and(
+    eq(userSrsState.userId, locals.user.id),
+    eq(userSrsState.srsItemId, body.srsItemId),
+    eq(userSrsState.skill, body.skill ?? 'reading'),
+    eq(userSrsState.modality, 'text'),
+    eq(userSrsState.direction, body.direction ?? 'recognition')
+  );
+  const row = (await db.select().from(userSrsState).where(key))[0];
+  if (!row) throw error(404, 'no such SRS state');
+  const prev: SrsState = { ease: row.ease, intervalDays: row.intervalDays, reps: row.reps, lapses: row.lapses };
+  const next = sm2(prev, qualityFor(body.result, true));
+  await db
+    .update(userSrsState)
+    .set({
+      ease: next.ease,
+      intervalDays: next.intervalDays,
+      reps: next.reps,
+      lapses: next.lapses,
+      dueAt: nextDue(new Date(), next.intervalDays)
+    })
+    .where(key);
+  return json({ ok: true });
+};

--- a/app/src/routes/learn/+page.server.ts
+++ b/app/src/routes/learn/+page.server.ts
@@ -1,12 +1,19 @@
 import type { PageServerLoad } from './$types';
 import { getDb } from '$lib/server/db';
-import { modules, lessons } from '$lib/server/db/schema';
-import { asc } from 'drizzle-orm';
+import { modules, lessons, lessonProgress } from '$lib/server/db/schema';
+import { asc, eq } from 'drizzle-orm';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ locals }) => {
   const db = getDb();
+  const progress = locals.user
+    ? await db
+        .select({ lessonId: lessonProgress.lessonId, status: lessonProgress.status })
+        .from(lessonProgress)
+        .where(eq(lessonProgress.userId, locals.user.id))
+    : [];
+  const progressById = new Map(progress.map((p) => [p.lessonId, p.status]));
   const mods = await db.select().from(modules).orderBy(asc(modules.tier), asc(modules.position));
-  const less = await db
+  const lessRows = await db
     .select({
       id: lessons.id,
       moduleId: lessons.moduleId,
@@ -17,6 +24,7 @@ export const load: PageServerLoad = async () => {
     })
     .from(lessons)
     .orderBy(asc(lessons.position));
+  const less = lessRows.map((l) => ({ ...l, progress: progressById.get(l.id) ?? null }));
 
   // Group: tier -> modules -> lessons. Tiers with no modules simply don't
   // appear (C1/C2 stay invisible until content exists).

--- a/app/src/routes/learn/+page.svelte
+++ b/app/src/routes/learn/+page.svelte
@@ -22,7 +22,11 @@
           <ul class="mt-3 divide-y divide-slate-100">
             {#each mod.lessons as lesson}
               <li class="flex items-center justify-between py-2">
-                <a href="/learn/{lesson.id}" class="text-teal-700 hover:underline">{lesson.title}</a>
+                <span>
+                  <a href="/learn/{lesson.id}" class="text-teal-700 hover:underline">{lesson.title}</a>
+                  {#if lesson.progress === 'completed'}<span class="ml-1 text-emerald-600" title="completed">✓</span>
+                  {:else if lesson.progress === 'in_progress'}<span class="ml-1 text-amber-500" title="in progress">…</span>{/if}
+                </span>
                 <span class="rounded-full px-2 py-0.5 text-xs {statusLabel[lesson.status].cls}"
                   >{statusLabel[lesson.status].text}</span
                 >

--- a/app/src/routes/learn/[lessonId]/+page.server.ts
+++ b/app/src/routes/learn/[lessonId]/+page.server.ts
@@ -3,11 +3,13 @@ import type { PageServerLoad } from './$types';
 import { getDb } from '$lib/server/db';
 import { lessons, contentBlocks, exercises } from '$lib/server/db/schema';
 import { eq, asc } from 'drizzle-orm';
+import { touchLesson } from '$lib/server/progress/record-attempt';
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, locals }) => {
   const db = getDb();
   const lesson = (await db.select().from(lessons).where(eq(lessons.id, params.lessonId)))[0];
   if (!lesson) throw error(404, 'Lesson not found');
+  if (locals.user) await touchLesson(locals.user.id, lesson.id);
 
   const blocks = await db
     .select()

--- a/app/src/routes/learn/[lessonId]/+page.svelte
+++ b/app/src/routes/learn/[lessonId]/+page.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
   import ExerciseHost from '$lib/engine/ExerciseHost.svelte';
+  import type { AnswerClass } from '$lib/engine/validate';
 
   let { data } = $props();
+
+  // Fire-and-forget attempt recording; the UI never blocks on it.
+  function record(exerciseId: string, result: AnswerClass) {
+    fetch('/api/attempts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ exerciseId, result })
+    }).catch(() => {});
+  }
   const statusLabel: Record<string, { text: string; cls: string }> = {
     draft: { text: 'draft', cls: 'bg-amber-100 text-amber-800' },
     reviewed: { text: 'AI-drafted, provisional', cls: 'bg-sky-100 text-sky-800' },
@@ -56,7 +66,7 @@
     <h2 class="mt-8 text-lg font-semibold text-slate-700">Practice</h2>
     <div class="mt-3 space-y-4">
       {#each data.exercises as exercise}
-        <ExerciseHost {exercise} />
+        <ExerciseHost {exercise} onResult={record} />
       {/each}
     </div>
   {/if}

--- a/app/src/routes/review/+page.server.ts
+++ b/app/src/routes/review/+page.server.ts
@@ -1,0 +1,16 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { dueSrsItems } from '$lib/server/progress/record-attempt';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) throw error(401, 'Not signed in');
+  const due = await dueSrsItems(locals.user.id);
+  return {
+    due: due.rows.map((r) => ({
+      srsItemId: r.srs_item_id as string,
+      skill: r.skill as string,
+      direction: r.direction as string,
+      payload: r.payload as { front: string; back: string }
+    }))
+  };
+};

--- a/app/src/routes/review/+page.svelte
+++ b/app/src/routes/review/+page.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  let { data } = $props();
+  let index = $state(0);
+  let flipped = $state(false);
+
+  const current = $derived(data.due[index] ?? null);
+
+  async function grade(knewIt: boolean) {
+    const item = current!;
+    await fetch('/api/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        srsItemId: item.srsItemId,
+        skill: item.skill,
+        direction: item.direction,
+        result: knewIt ? 'correct' : 'wrong'
+      })
+    }).catch(() => {});
+    flipped = false;
+    index += 1;
+  }
+</script>
+
+<main class="mx-auto max-w-3xl p-8">
+  <a href="/" class="text-sm text-teal-700 hover:underline">&larr; Home</a>
+  <h1 class="mt-2 text-2xl font-bold text-teal-700">Review</h1>
+
+  {#if !current}
+    <p class="mt-6 text-slate-600" data-testid="review-done">
+      Nothing due — come back later. 🎉
+    </p>
+  {:else}
+    <p class="mt-1 text-sm text-slate-500">{data.due.length - index} due</p>
+    <button
+      onclick={() => (flipped = !flipped)}
+      class="mt-6 w-full rounded-xl border border-slate-200 bg-white p-10 text-center text-xl font-semibold text-slate-700 shadow-md hover:bg-slate-50"
+      aria-label="flip review card"
+    >
+      {flipped ? current.payload.back : current.payload.front}
+    </button>
+    {#if flipped}
+      <div class="mt-4 flex justify-center gap-3">
+        <button onclick={() => grade(false)} class="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50">Didn't know</button>
+        <button onclick={() => grade(true)} class="rounded-md border border-emerald-300 px-4 py-2 text-sm text-emerald-700 hover:bg-emerald-50">Knew it</button>
+      </div>
+    {/if}
+  {/if}
+</main>

--- a/docs/superpowers/plans/2026-07-05-sp1-plan5-progress.md
+++ b/docs/superpowers/plans/2026-07-05-sp1-plan5-progress.md
@@ -1,0 +1,38 @@
+# SP1 Plan 5 — Progress Tracking & SRS Scaffold
+
+**Goal:** Per-user progress that survives devices, and correct SRS scheduling data (spec §6.2–6.3) — Codex-hardened model: state per **item × skill × modality × direction**.
+
+## Schema (all user-FKs ON DELETE CASCADE → GDPR delete stays one statement)
+
+- `exercise_progress(user_id, exercise_id, first_result, best_result, attempts, last_attempt_at, pk(user,exercise))`
+- `lesson_progress(user_id, lesson_id, status in_progress|completed, first_accuracy real, last_visited_at, pk(user,lesson))`
+- `user_srs_state(user_id, srs_item_id, skill, modality, direction, ease real, interval_days real, due_at, reps, lapses, pk(user,item,skill,modality,direction))`
+
+## Scheduler
+
+SM-2 (pure, unit-tested): `sm2(prev, quality 0-5) → next`. Result mapping:
+correct→5, accent→3, wrong→1; card self-grade knew→4 / didn't→1.
+Direction: card_flip = `recognition`, all others `production`; modality `text`
+(listening/speaking arrive SP3); skill from lesson `skill_tags[0] ?? reading`.
+
+## Flow
+
+`ExerciseHost.onResult` → `POST /api/attempts {exerciseId, result}` →
+transaction: upsert exercise_progress (first_result immutable), recompute
+lesson_progress (completed when every lesson exercise attempted;
+first_accuracy = share of exercises whose FIRST attempt was correct), update
+user_srs_state for linked srs_items. Lesson page load touches
+last_visited_at. `/learn` shows per-lesson progress; `/review` = minimal
+due-items card-flip session. `/account/export` gains progress + SRS sections.
+
+## Tasks
+1. Schema + migration + sm2 unit tests
+2. /api/attempts + recompute logic (integration-tested)
+3. Client wiring (ExerciseHost→POST), /learn indicators, /review page, export
+4. e2e + deploy + live verify
+
+## DoD
+- [ ] sm2 unit-tested (repeat correct grows interval; wrong resets + lapse)
+- [ ] Attempts idempotently aggregate; first_result never overwritten
+- [ ] Lesson completes when all exercises attempted; accuracy correct
+- [ ] /review schedules due items; export includes progress+SRS; live verify


### PR DESCRIPTION
Plan 5. exercise_progress (first_result immutable, best/attempts),
lesson_progress (completed when all exercises attempted,
first-attempt accuracy), user_srs_state keyed item x skill x modality
x direction (Codex-hardened model), all user FKs cascade for GDPR
delete. Pure SM-2 scheduler unit-tested (7 tests); POST /api/attempts
transactional; lesson page touches last-visited; /learn shows
progress markers; /review = minimal due-item session via /api/review;
export gains progress+SRS sections. Unit 37/37, e2e 18/18.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
