### PR TITLE
fix: flashcard affordance (dogfooding)

### DIFF
--- a/app/e2e/lesson.spec.ts
+++ b/app/e2e/lesson.spec.ts
@@ -38,5 +38,5 @@ test('card flip: flip and self-grade', async ({ page }) => {
   await ex.getByLabel('flip card').click();
   await expect(ex.getByLabel('flip card')).toContainText('hi / bye');
   await ex.getByRole('button', { name: 'Knew it' }).click();
-  await expect(ex.getByTestId('feedback')).toContainText('Recorded');
+  await expect(ex.getByTestId('feedback')).toContainText('Saved');
 });

--- a/app/src/lib/engine/components/CardFlip.svelte
+++ b/app/src/lib/engine/components/CardFlip.svelte
@@ -13,19 +13,34 @@
 </script>
 
 <div>
+  <p class="text-sm font-semibold text-slate-500">
+    🃏 Flashcard — do you know what this means? Recall it, then tap the card to check.
+  </p>
   <button
-    onclick={() => (flipped = !flipped)}
-    class="w-full rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-lg font-semibold text-slate-700 hover:bg-slate-100"
+    onclick={() => !graded && (flipped = !flipped)}
+    class="mt-2 w-full rounded-xl border border-slate-200 bg-slate-50 p-6 text-center hover:bg-slate-100"
     aria-label="flip card"
   >
-    {flipped ? payload.back : payload.front}
+    {#if graded}
+      <span class="text-lg font-semibold text-slate-700">{payload.front}</span>
+      <span class="mx-2 text-slate-400">=</span>
+      <span class="text-lg text-teal-700">{payload.back}</span>
+    {:else if flipped}
+      <span class="text-lg font-semibold text-slate-700">{payload.back}</span>
+    {:else}
+      <span class="text-lg font-semibold text-slate-700">{payload.front}</span>
+      <span class="mt-1 block text-xs font-normal text-slate-400">tap to reveal</span>
+    {/if}
   </button>
   {#if flipped && !graded}
-    <div class="mt-2 flex justify-center gap-3">
+    <p class="mt-2 text-center text-xs text-slate-500">Be honest — this schedules when you'll see the word again.</p>
+    <div class="mt-1 flex justify-center gap-3">
       <button onclick={() => grade(false)} class="rounded-md border border-red-300 px-3 py-1 text-sm text-red-700 hover:bg-red-50">Didn't know</button>
       <button onclick={() => grade(true)} class="rounded-md border border-emerald-300 px-3 py-1 text-sm text-emerald-700 hover:bg-emerald-50">Knew it</button>
     </div>
   {:else if graded}
-    <p class="mt-2 text-center text-sm text-slate-500" data-testid="feedback">Recorded.</p>
+    <p class="mt-2 text-center text-sm text-slate-500" data-testid="feedback">
+      Saved — this word will come back for review at the right time.
+    </p>
   {/if}
 </div>

--- a/app/src/routes/review/+page.svelte
+++ b/app/src/routes/review/+page.svelte
@@ -31,13 +31,20 @@
       Nothing due — come back later. 🎉
     </p>
   {:else}
-    <p class="mt-1 text-sm text-slate-500">{data.due.length - index} due</p>
+    <p class="mt-1 text-sm text-slate-500">
+      {data.due.length - index} due — recall each word, then tap the card to check yourself.
+    </p>
     <button
       onclick={() => (flipped = !flipped)}
       class="mt-6 w-full rounded-xl border border-slate-200 bg-white p-10 text-center text-xl font-semibold text-slate-700 shadow-md hover:bg-slate-50"
       aria-label="flip review card"
     >
-      {flipped ? current.payload.back : current.payload.front}
+      {#if flipped}
+        {current.payload.back}
+      {:else}
+        {current.payload.front}
+        <span class="mt-1 block text-xs font-normal text-slate-400">tap to reveal</span>
+      {/if}
     </button>
     {#if flipped}
       <div class="mt-4 flex justify-center gap-3">


### PR DESCRIPTION
Dogfooding finding (Jaypaul): the card-flip exercise rendered a bare
word with no indication it was a flashcard or what to do. Now: an
explicit instruction line, 'tap to reveal' hint on the front, honesty
note explaining the self-grade drives the review schedule, front=back
summary after grading, and 'Saved - this word will come back for
review' instead of the opaque 'Recorded.' Same affordance added to
the /review card. e2e 21/21.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
