### PR TITLE
feat: lesson prev/next navigation (dogfooding)

### DIFF
--- a/app/e2e/lesson-nav.spec.ts
+++ b/app/e2e/lesson-nav.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ extraHTTPHeaders: { 'X-Forwarded-User': `e2e-nav-${Date.now()}@example.com` } });
+
+test('lessons chain forward without returning to the curriculum', async ({ page }) => {
+  // smoke-test (position 0) -> alphabet (1) -> vowel-harmony (2) ...
+  await page.goto('/learn/a1-smoke-test');
+  await expect(page.getByTestId('next-lesson')).toContainText('alphabet');
+  await page.getByTestId('next-lesson').click();
+  await page.waitForURL('**/learn/a1-alphabet');
+  await expect(page.locator('h1')).toContainText('alphabet');
+  await expect(page.getByTestId('prev-lesson')).toBeVisible();
+  await page.getByTestId('next-lesson').click();
+  await page.waitForURL('**/learn/a1-vowel-harmony');
+  await expect(page.locator('h1')).toContainText('Vowel harmony');
+});
+
+test('last lesson points back to the curriculum', async ({ page }) => {
+  await page.goto('/learn/a1-numbers'); // currently the last lesson
+  await expect(page.getByTestId('next-lesson')).toContainText('Back to curriculum');
+});

--- a/app/src/lib/engine/ExerciseHost.svelte
+++ b/app/src/lib/engine/ExerciseHost.svelte
@@ -20,7 +20,10 @@
     dialogue: Dialogue
   };
 
-  const Component = components[exercise.type] as typeof FillBlank | undefined;
+  // $derived: must track the prop, not capture its initial value —
+  // positional reuse across navigations otherwise pairs an old component
+  // type with a new payload.
+  const Component = $derived(components[exercise.type] as typeof FillBlank | undefined);
   const report = (r: AnswerClass) => onResult?.(exercise.id, r);
 </script>
 

--- a/app/src/routes/assess/[assessmentId]/+page.svelte
+++ b/app/src/routes/assess/[assessmentId]/+page.svelte
@@ -29,7 +29,7 @@
   <p class="mt-2 text-sm text-slate-500">{answered}/{data.exercises.length} answered — first attempt counts.</p>
 
   <div class="mt-6 space-y-4">
-    {#each data.exercises as exercise}
+    {#each data.exercises as exercise (exercise.id)}
       <ExerciseHost {exercise} onResult={record} />
     {/each}
   </div>

--- a/app/src/routes/learn/[lessonId]/+page.server.ts
+++ b/app/src/routes/learn/[lessonId]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getDb } from '$lib/server/db';
-import { lessons, contentBlocks, exercises } from '$lib/server/db/schema';
+import { lessons, contentBlocks, exercises, modules } from '$lib/server/db/schema';
 import { eq, asc } from 'drizzle-orm';
 import { touchLesson } from '$lib/server/progress/record-attempt';
 
@@ -10,6 +10,17 @@ export const load: PageServerLoad = async ({ params, locals }) => {
   const lesson = (await db.select().from(lessons).where(eq(lessons.id, params.lessonId)))[0];
   if (!lesson) throw error(404, 'Lesson not found');
   if (locals.user) await touchLesson(locals.user.id, lesson.id);
+
+  // Prev/next in curriculum order (tier, module position, lesson position) —
+  // same ordering as /learn, so navigation never has to bounce back there.
+  const ordered = await db
+    .select({ id: lessons.id, title: lessons.title })
+    .from(lessons)
+    .innerJoin(modules, eq(modules.id, lessons.moduleId))
+    .orderBy(asc(modules.tier), asc(modules.position), asc(lessons.position));
+  const index = ordered.findIndex((l) => l.id === lesson.id);
+  const prev = index > 0 ? ordered[index - 1] : null;
+  const next = index >= 0 && index < ordered.length - 1 ? ordered[index + 1] : null;
 
   const blocks = await db
     .select()
@@ -32,6 +43,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
       sources: lesson.sources
     },
     blocks,
-    exercises: exs
+    exercises: exs,
+    prev,
+    next
   };
 };

--- a/app/src/routes/learn/[lessonId]/+page.svelte
+++ b/app/src/routes/learn/[lessonId]/+page.svelte
@@ -66,11 +66,31 @@
   {#if data.exercises.length > 0}
     <h2 class="mt-8 text-lg font-semibold text-slate-700">Practice</h2>
     <div class="mt-3 space-y-4">
-      {#each data.exercises as exercise}
+      <!-- keyed by id: exercises must be destroyed/recreated across client-side
+           navigations, or stale component instances crash on the next lesson's
+           payloads (found via prev/next navigation, 2026-07-05) -->
+      {#each data.exercises as exercise (exercise.id)}
         <ExerciseHost {exercise} onResult={record} />
       {/each}
     </div>
   {/if}
+
+  <nav class="mt-8 flex items-center justify-between gap-4">
+    {#if data.prev}
+      <a href="/learn/{data.prev.id}" class="rounded-md border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:bg-slate-50" data-testid="prev-lesson"
+        >&larr; {data.prev.title}</a
+      >
+    {:else}<span></span>{/if}
+    {#if data.next}
+      <a href="/learn/{data.next.id}" class="rounded-md bg-teal-700 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-800" data-testid="next-lesson"
+        >{data.next.title} &rarr;</a
+      >
+    {:else}
+      <a href="/learn" class="rounded-md bg-teal-700 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-800" data-testid="next-lesson"
+        >Back to curriculum &rarr;</a
+      >
+    {/if}
+  </nav>
 
   <FeedbackForm lessonId={data.lesson.id} />
 


### PR DESCRIPTION
Dogfooding finding (Jaypaul): finishing a lesson dead-ended; you had
to bounce back to the curriculum. Lesson pages now chain prev/next in
curriculum order (tier, module position, lesson position); the last
lesson links back to the curriculum.

Building this surfaced a real Svelte 5 bug the earlier
state_referenced_locally warning pointed at: ExerciseHost captured
components[exercise.type] at init, so client-side navigation reused
instances positionally and paired old component types with the next
page's payloads (payload.prompt.split on undefined -> render crash ->
stale DOM). Fixed with keyed {#each (exercise.id)} on lesson +
assessment pages and  component lookup. e2e 23/23.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
