### PR TITLE
fix: AI env passthrough + cold-start timeout

### DIFF
--- a/app/src/lib/server/ai/provider.ts
+++ b/app/src/lib/server/ai/provider.ts
@@ -18,7 +18,9 @@ export interface ChatResult {
   provider: string;
 }
 
-const TIMEOUT_MS = 60_000;
+// 120s: Ollama cold-loads the model into VRAM on first request (~30-60s
+// observed on HAL) before generating.
+const TIMEOUT_MS = 120_000;
 
 export function resolveProvider(): 'anthropic' | 'openai-compat' | 'mock' {
   const forced = process.env.AI_PROVIDER;

--- a/deploy/hal/nyolc.yml
+++ b/deploy/hal/nyolc.yml
@@ -32,6 +32,12 @@ services:
       PORT: 3000
       DATABASE_URL: "postgres://nyolc:${NYOLC_PG_PASSWORD}@postgresql:5432/nyolc?sslmode=disable"
       ORIGIN: ${NYOLC_BASE_URL}
+      # AI tutor backend: Ollama by default; setting NYOLC_ANTHROPIC_API_KEY
+      # in ~/docker/.env upgrades to Claude automatically (adapter logic).
+      AI_BASE_URL: ${NYOLC_AI_BASE_URL:-}
+      AI_MODEL: ${NYOLC_AI_MODEL:-}
+      ANTHROPIC_API_KEY: ${NYOLC_ANTHROPIC_API_KEY:-}
+      AI_DAILY_LIMIT: ${NYOLC_AI_DAILY_LIMIT:-100}
     labels:
       - "diun.enable=true"
       - "dashboard.enabled=true"


### PR DESCRIPTION
- **feat(deploy): AI env passthrough for nyolc (ollama default, claude on key)**
- **fix(ai): 120s provider timeout for Ollama cold model loads**
