### PR TITLE
feat: SP6 core - feedback triage + outcome adapter

### DIFF
--- a/app/e2e/admin-feedback.spec.ts
+++ b/app/e2e/admin-feedback.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+const learner = `e2e-fb-${Date.now()}@example.com`;
+
+test('non-admin cannot open the triage page', async ({ request }) => {
+  const res = await request.get('/admin/feedback', {
+    headers: { 'X-Forwarded-User': learner }
+  });
+  expect(res.status()).toBe(403);
+});
+
+test('admin triages a submission end-to-end', async ({ browser }) => {
+  // learner submits
+  const learnerCtx = await browser.newContext({ extraHTTPHeaders: { 'X-Forwarded-User': learner } });
+  const lp = await learnerCtx.newPage();
+  await lp.goto('/learn/a1-greetings');
+  await lp.getByRole('button', { name: /Suggest a correction/ }).click();
+  await lp.getByLabel(/What's wrong/).fill('E2E triage test suggestion.');
+  await lp.getByRole('button', { name: 'Send' }).click();
+  await expect(lp.getByTestId('feedback-sent')).toBeVisible();
+  await learnerCtx.close();
+
+  // admin resolves
+  const adminCtx = await browser.newContext({
+    extraHTTPHeaders: { 'X-Forwarded-User': 'jaypaulb@gmail.com' }
+  });
+  const ap = await adminCtx.newPage();
+  await ap.goto('/admin/feedback');
+  const row = ap.getByTestId('feedback-row').filter({ hasText: 'E2E triage test suggestion.' }).first();
+  await expect(row).toBeVisible();
+  await row.getByRole('button', { name: 'Accept' }).click();
+  await expect(
+    ap.getByTestId('feedback-row').filter({ hasText: 'E2E triage test suggestion.' }).first()
+  ).toContainText('accepted');
+  await adminCtx.close();
+});

--- a/app/src/lib/server/feedback/outcome.ts
+++ b/app/src/lib/server/feedback/outcome.ts
@@ -1,0 +1,40 @@
+import { getDb } from '$lib/server/db';
+import { feedback, users } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Outcome notification adapter (SP6). Provider decision (transactional email
+ * for noreply@nyolc.cc) is deliberately NOT made autonomously — the default
+ * sender LOGS the message it would send. Swapping in a real provider later
+ * only touches sendOutcomeEmail.
+ */
+async function sendOutcomeEmail(to: string, subject: string, body: string) {
+  console.info(`[outcome-email:log-only] to=${to} subject="${subject}"\n${body}`);
+}
+
+export async function resolveFeedback(
+  feedbackId: string,
+  decision: 'accepted' | 'rejected',
+  note: string
+) {
+  const db = getDb();
+  const row = (await db.select().from(feedback).where(eq(feedback.id, feedbackId)))[0];
+  if (!row) throw new Error('no such feedback');
+  await db.update(feedback).set({ status: decision }).where(eq(feedback.id, feedbackId));
+
+  if (row.consentContact === 1) {
+    const user = (await db.select().from(users).where(eq(users.id, row.userId)))[0];
+    if (user) {
+      const outcome =
+        decision === 'accepted'
+          ? 'we agreed and the fix is on its way into the course'
+          : 'after review we decided to keep the current version';
+      await sendOutcomeEmail(
+        user.email,
+        'Your magyarul.nyolc.cc suggestion — outcome',
+        `Köszönjük! You suggested:\n\n> ${row.message}\n\nOutcome: ${outcome}.\n${note ? `Note: ${note}\n` : ''}\nEvery suggestion makes the course better — thank you.`
+      );
+    }
+  }
+  return { notified: row.consentContact === 1 };
+}

--- a/app/src/routes/admin/feedback/+page.server.ts
+++ b/app/src/routes/admin/feedback/+page.server.ts
@@ -1,0 +1,50 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+import { getDb } from '$lib/server/db';
+import { feedback, users } from '$lib/server/db/schema';
+import { eq, desc } from 'drizzle-orm';
+import { resolveFeedback } from '$lib/server/feedback/outcome';
+
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ?? 'jaypaulb@gmail.com')
+  .split(',')
+  .map((s) => s.trim().toLowerCase());
+
+function requireAdmin(user: { email: string } | null) {
+  if (!user || !ADMIN_EMAILS.includes(user.email.toLowerCase())) {
+    throw error(403, 'Admins only');
+  }
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  requireAdmin(locals.user);
+  const rows = await getDb()
+    .select({
+      id: feedback.id,
+      lessonId: feedback.lessonId,
+      exerciseId: feedback.exerciseId,
+      contentVersion: feedback.contentVersion,
+      message: feedback.message,
+      consent: feedback.consentContact,
+      status: feedback.status,
+      githubIssue: feedback.githubIssue,
+      createdAt: feedback.createdAt,
+      email: users.email
+    })
+    .from(feedback)
+    .leftJoin(users, eq(users.id, feedback.userId))
+    .orderBy(desc(feedback.createdAt))
+    .limit(100);
+  return { rows: rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() })) };
+};
+
+export const actions: Actions = {
+  resolve: async ({ locals, request }) => {
+    requireAdmin(locals.user);
+    const form = await request.formData();
+    const id = String(form.get('id') ?? '');
+    const decision = String(form.get('decision') ?? '');
+    if (!id || (decision !== 'accepted' && decision !== 'rejected')) throw error(400, 'bad form');
+    await resolveFeedback(id, decision, String(form.get('note') ?? ''));
+    throw redirect(303, '/admin/feedback');
+  }
+};

--- a/app/src/routes/admin/feedback/+page.svelte
+++ b/app/src/routes/admin/feedback/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  let { data } = $props();
+  const statusCls: Record<string, string> = {
+    new: 'bg-amber-100 text-amber-800',
+    triaged: 'bg-sky-100 text-sky-800',
+    accepted: 'bg-emerald-100 text-emerald-800',
+    rejected: 'bg-slate-200 text-slate-600'
+  };
+</script>
+
+<main class="mx-auto max-w-4xl p-8">
+  <a href="/" class="text-sm text-teal-700 hover:underline">&larr; Home</a>
+  <h1 class="mt-2 text-2xl font-bold text-teal-700">Feedback triage</h1>
+  <p class="text-sm text-slate-500">
+    {data.rows.length} most recent. Resolving notifies consenting submitters (log-only until an email provider is wired).
+  </p>
+
+  <div class="mt-6 space-y-4">
+    {#each data.rows as row}
+      <div class="rounded-xl bg-white p-4 shadow-md" data-testid="feedback-row">
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-xs text-slate-400"
+            >{new Date(row.createdAt).toLocaleString()} · {row.lessonId ?? row.exerciseId ?? 'general'}
+            v{row.contentVersion ?? '?'} · {row.email ?? 'deleted user'}
+            {#if row.consent === 1}· 📧 wants outcome{/if}
+            {#if row.githubIssue}· <a class="text-teal-700 hover:underline" href="https://github.com/jaypaulb/learninghungarian/issues/{row.githubIssue}">#{row.githubIssue}</a>{/if}
+          </span>
+          <span class="rounded-full px-2 py-0.5 text-xs {statusCls[row.status]}">{row.status}</span>
+        </div>
+        <p class="mt-2 whitespace-pre-wrap text-sm text-slate-700">{row.message}</p>
+        {#if row.status === 'new' || row.status === 'triaged'}
+          <form method="POST" action="?/resolve" class="mt-3 flex flex-wrap items-center gap-2">
+            <input type="hidden" name="id" value={row.id} />
+            <input name="note" placeholder="note to submitter (optional)" class="w-64 rounded-md border border-slate-300 px-2 py-1 text-sm" />
+            <button name="decision" value="accepted" class="rounded-md bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-700">Accept</button>
+            <button name="decision" value="rejected" class="rounded-md border border-slate-300 px-3 py-1 text-sm text-slate-600 hover:bg-slate-50">Reject</button>
+          </form>
+        {/if}
+      </div>
+    {:else}
+      <p class="text-slate-500">No feedback yet.</p>
+    {/each}
+  </div>
+</main>

--- a/deploy/hal/nyolc.yml
+++ b/deploy/hal/nyolc.yml
@@ -42,6 +42,7 @@ services:
       STT_BASE_URL: ${NYOLC_STT_BASE_URL:-}
       # feedback -> PII-free GitHub issues (empty = skipped-with-log)
       GITHUB_FEEDBACK_TOKEN: ${NYOLC_GITHUB_FEEDBACK_TOKEN:-}
+      ADMIN_EMAILS: ${NYOLC_ADMIN_EMAILS:-jaypaulb@gmail.com}
     labels:
       - "diun.enable=true"
       - "dashboard.enabled=true"

--- a/docs/superpowers/specs/2026-07-05-tier-aware-platform-design.md
+++ b/docs/superpowers/specs/2026-07-05-tier-aware-platform-design.md
@@ -282,7 +282,7 @@ The path to B2-grade accuracy **without a paid tutor**. Two layers.
 ## 10. Risks & open questions
 
 - **Accuracy without a native gate** — accepted trade-off (Jaypaul): provisional labeling + mandatory source citation + MoE + crowd. Residual risk of two LLMs sharing a wrong answer; mitigations = citations, prominent provisional badge, crowd weighting, assessment held to higher scrutiny, Jaypaul tie-break on holds.
-- **Which accredited B2 exam** to back-design assessments from (ECL / state-Origó / EuroExam) — pin at SP5; affects assessment blueprints, not SP1 code.
+- **Which accredited B2 exam** — provisionally **ECL** (chosen autonomously 2026-07-05: the most commonly accepted exam for Hungarian residency/citizenship purposes, four-skill format matching our engine, exam centres across Hungary). Confirm or override before B1/B2 assessment blueprints are authored (SP5 remainder).
 - **HAL specifics** — confirm Docker + reverse-proxy/TLS + backup location before build.
 - **Content-format + SRS-algorithm** finalization — decide at plan time (Drizzle already fixed).
 - **Trust/reputation model** (SP6) is now load-bearing for auto-merge — design before enabling any auto-merge.


### PR DESCRIPTION
/admin/feedback (ADMIN_EMAILS-gated, default jaypaulb@gmail.com):
lists submissions with content refs, consent, and linked GH issue;
accept/reject updates status and notifies consenting submitters via
the outcome adapter - LOG-ONLY sender until an email provider is
chosen (deliberately not decided autonomously). Spec: ECL pinned
provisionally as the target B2 exam. e2e 35/35 incl. full
learner-submit -> admin-resolve loop.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
