### PR TITLE
feat: outcome emails via noreply@nyolc.cc (A2 SMTP)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "drizzle-orm": "^0.36.4",
+        "nodemailer": "^6.10.1",
         "pg": "^8.22.0",
         "yaml": "^2.9.0",
         "zod": "^3.25.76"
@@ -18,6 +19,7 @@
         "@sveltejs/adapter-node": "^5.2.0",
         "@sveltejs/kit": "^2.5.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
+        "@types/nodemailer": "^8.0.1",
         "@types/pg": "^8.20.0",
         "autoprefixer": "^10.4.0",
         "drizzle-kit": "^0.28.1",
@@ -1607,6 +1609,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -3246,6 +3258,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "@sveltejs/adapter-node": "^5.2.0",
     "@sveltejs/kit": "^2.5.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@types/nodemailer": "^8.0.1",
     "@types/pg": "^8.20.0",
     "autoprefixer": "^10.4.0",
     "drizzle-kit": "^0.28.1",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.36.4",
+    "nodemailer": "^6.10.1",
     "pg": "^8.22.0",
     "yaml": "^2.9.0",
     "zod": "^3.25.76"

--- a/app/src/lib/server/feedback/outcome.ts
+++ b/app/src/lib/server/feedback/outcome.ts
@@ -3,13 +3,31 @@ import { feedback, users } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 
 /**
- * Outcome notification adapter (SP6). Provider decision (transactional email
- * for noreply@nyolc.cc) is deliberately NOT made autonomously — the default
- * sender LOGS the message it would send. Swapping in a real provider later
- * only touches sendOutcomeEmail.
+ * Outcome notification adapter (SP6). Real sender: SMTP via A2 Hosting
+ * (noreply@nyolc.cc mailbox; SPF/DKIM/DMARC live on nyolc.cc, 2026-07-06).
+ * Without SMTP_PASS in env it degrades to log-only — visible, never silent.
  */
-async function sendOutcomeEmail(to: string, subject: string, body: string) {
-  console.info(`[outcome-email:log-only] to=${to} subject="${subject}"\n${body}`);
+import nodemailer from 'nodemailer';
+
+export async function sendOutcomeEmail(to: string, subject: string, body: string) {
+  const pass = process.env.SMTP_PASS;
+  if (!pass) {
+    console.info(`[outcome-email:log-only] to=${to} subject="${subject}"\n${body}`);
+    return { sent: false as const };
+  }
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST || 'mail.nyolc.cc',
+    port: Number(process.env.SMTP_PORT || 465),
+    secure: true,
+    auth: { user: process.env.SMTP_USER || 'noreply@nyolc.cc', pass }
+  });
+  await transporter.sendMail({
+    from: process.env.MAIL_FROM || 'Magyarul <noreply@nyolc.cc>',
+    to,
+    subject,
+    text: body
+  });
+  return { sent: true as const };
 }
 
 export async function resolveFeedback(

--- a/deploy/hal/nyolc.yml
+++ b/deploy/hal/nyolc.yml
@@ -43,6 +43,8 @@ services:
       # feedback -> PII-free GitHub issues (empty = skipped-with-log)
       GITHUB_FEEDBACK_TOKEN: ${NYOLC_GITHUB_FEEDBACK_TOKEN:-}
       ADMIN_EMAILS: ${NYOLC_ADMIN_EMAILS:-jaypaulb@gmail.com}
+      # outcome emails via A2 Hosting SMTP (noreply@nyolc.cc); empty = log-only
+      SMTP_PASS: ${NYOLC_SMTP_PASS:-}
     labels:
       - "diun.enable=true"
       - "dashboard.enabled=true"


### PR DESCRIPTION
Mailbox created on the existing A2 account (nyolc.cc was already an
addon domain); MX/A/SPF/DKIM/DMARC live in Cloudflare mirroring the
proven thrucible.com setup. nodemailer over ssl:465; without
SMTP_PASS the adapter stays visibly log-only. Password in pass at
a2hosting/noreply-nyolc-mailbox.

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
