### PR TITLE
feat: energize pass (colorize + animate + onboard)

### DIFF
--- a/app/e2e/home-momentum.spec.ts
+++ b/app/e2e/home-momentum.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+test.use({ extraHTTPHeaders: { 'X-Forwarded-User': `e2e-momentum-${Date.now()}@example.com` } });
+
+test('fresh learner gets the Kezdjük start hero', async ({ page }) => {
+  await page.goto('/');
+  const hero = page.getByTestId('momentum');
+  await expect(hero).toContainText('Kezdjük');
+  await expect(hero).toContainText('lessons done');
+  await expect(page.getByTestId('continue')).toBeVisible();
+});
+
+test('after an attempt the hero flips to Continue', async ({ page, request }) => {
+  await request.post('/api/attempts', {
+    headers: { Origin: 'http://localhost:3000' },
+    data: { exerciseId: 'a1-smoke-test-ex1', result: 'wrong' }
+  });
+  await page.goto('/');
+  await expect(page.getByTestId('momentum')).toContainText('Continue where you left off');
+  // wrong answer scheduled an SRS item due now
+  await expect(page.getByTestId('momentum')).toContainText('due for review');
+});

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -11,8 +11,70 @@
   }
   /* Motion is decorative here; stand still for those who ask (WCAG 2.3.3). */
   @media (prefers-reduced-motion: reduce) {
-    .animate-pulse {
-      animation: none;
+    .animate-pulse,
+    [data-testid^='feedback'],
+    .celebrate,
+    .celebrate .spark {
+      animation: none !important;
+    }
+  }
+}
+
+@layer components {
+  /* Feedback pops in: acknowledgment, 180ms, ease-out only. */
+  [data-testid^='feedback'] {
+    display: inline-block;
+    animation: feedback-pop 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  @keyframes feedback-pop {
+    from {
+      opacity: 0;
+      transform: scale(0.92) translateY(2px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+
+  /* The one hero motion: passing a checkpoint. */
+  .celebrate {
+    animation: celebrate-in 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  @keyframes celebrate-in {
+    0% {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+    60% {
+      transform: scale(1.03);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  .celebrate .spark {
+    display: inline-block;
+    animation: spark-float 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  .celebrate .spark:nth-child(2) {
+    animation-delay: 0.12s;
+  }
+  .celebrate .spark:nth-child(3) {
+    animation-delay: 0.24s;
+  }
+  @keyframes spark-float {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.6);
+    }
+    30% {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-14px) scale(1.15);
     }
   }
 }

--- a/app/src/app.html
+++ b/app/src/app.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover" class="bg-slate-100 text-slate-700">
+  <body data-sveltekit-preload-data="hover" class="bg-stone-100 text-slate-700">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -1,5 +1,56 @@
 import type { PageServerLoad } from './$types';
+import { getDb } from '$lib/server/db';
+import { lessonProgress, lessons, userSrsState } from '$lib/server/db/schema';
+import { eq, desc, and, lte, sql } from 'drizzle-orm';
 
 export const load: PageServerLoad = async ({ locals }) => {
-  return { user: locals.user ? { email: locals.user.email } : null };
+  if (!locals.user) return { user: null, momentum: null };
+  const db = getDb();
+
+  const [latest] = await db
+    .select({ lessonId: lessonProgress.lessonId, status: lessonProgress.status, title: lessons.title })
+    .from(lessonProgress)
+    .innerJoin(lessons, eq(lessons.id, lessonProgress.lessonId))
+    .where(eq(lessonProgress.userId, locals.user.id))
+    .orderBy(desc(lessonProgress.lastVisitedAt))
+    .limit(1);
+
+  const [{ completed }] = await db
+    .select({ completed: sql<number>`count(*)` })
+    .from(lessonProgress)
+    .where(and(eq(lessonProgress.userId, locals.user.id), eq(lessonProgress.status, 'completed')));
+
+  const [{ total }] = await db.select({ total: sql<number>`count(*)` }).from(lessons);
+
+  const [{ due }] = await db
+    .select({ due: sql<number>`count(*)` })
+    .from(userSrsState)
+    .where(and(eq(userSrsState.userId, locals.user.id), lte(userSrsState.dueAt, new Date())));
+
+  // Next lesson: latest in-progress one, or the first not-yet-completed lesson.
+  let next: { id: string; title: string } | null = null;
+  if (latest && latest.status === 'in_progress') {
+    next = { id: latest.lessonId, title: latest.title };
+  } else {
+    const [firstOpen] = await db
+      .select({ id: lessons.id, title: lessons.title })
+      .from(lessons)
+      .where(
+        sql`${lessons.id} NOT IN (SELECT lesson_id FROM lesson_progress WHERE user_id = ${locals.user.id} AND status = 'completed')`
+      )
+      .orderBy(lessons.position)
+      .limit(1);
+    if (firstOpen) next = firstOpen;
+  }
+
+  return {
+    user: { email: locals.user.email },
+    momentum: {
+      next,
+      started: Boolean(latest),
+      completed: Number(completed),
+      total: Number(total),
+      due: Number(due)
+    }
+  };
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,13 +1,46 @@
 <script lang="ts">
   let { data } = $props();
+  const m = $derived(data.momentum);
 </script>
 
 <main class="mx-auto max-w-3xl p-8">
   <h1 class="text-2xl font-bold text-teal-700">Learning Hungarian</h1>
-  <p class="mt-2 text-slate-600">Zero to B2, magyarul.</p>
+  <p class="mt-1 text-slate-600">Zero to B2, magyarul.</p>
+
+  {#if m}
+    <section class="mt-6 rounded-xl bg-white p-6 shadow-md" data-testid="momentum">
+      {#if m.next}
+        <p class="text-sm font-semibold uppercase tracking-wide text-slate-500">
+          {m.started ? 'Continue where you left off' : 'Kezdjük! (Let’s begin!)'}
+        </p>
+        <a
+          href="/learn/{m.next.id}"
+          class="mt-2 inline-block rounded-md bg-teal-700 px-5 py-3 text-base font-semibold text-white hover:bg-teal-800"
+          data-testid="continue"
+          >{m.next.title} &rarr;</a
+        >
+      {:else}
+        <p class="text-base font-semibold text-emerald-700">
+          Every published lesson completed. Szép munka! 🎉
+        </p>
+      {/if}
+      <div class="mt-4 flex flex-wrap gap-2 text-sm">
+        <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-800"
+          >{m.completed}/{m.total} lessons done</span
+        >
+        {#if m.due > 0}
+          <a href="/review" class="rounded-full bg-amber-100 px-3 py-1 text-amber-800 hover:bg-amber-200"
+            >{m.due} word{m.due === 1 ? '' : 's'} due for review</a
+          >
+        {:else}
+          <span class="rounded-full bg-stone-200 px-3 py-1 text-slate-600">review queue clear</span>
+        {/if}
+      </div>
+    </section>
+  {/if}
 
   <nav class="mt-6 flex gap-3">
-    <a href="/learn" class="rounded-md bg-teal-700 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-800">Curriculum</a>
+    <a href="/learn" class="rounded-md border border-teal-700 px-4 py-2 text-sm font-semibold text-teal-700 hover:bg-teal-50">Curriculum</a>
     <a href="/review" class="rounded-md border border-teal-700 px-4 py-2 text-sm font-semibold text-teal-700 hover:bg-teal-50">Review</a>
     <a href="/tutor" class="rounded-md border border-teal-700 px-4 py-2 text-sm font-semibold text-teal-700 hover:bg-teal-50">Tutor</a>
   </nav>

--- a/app/src/routes/assess/[assessmentId]/+page.svelte
+++ b/app/src/routes/assess/[assessmentId]/+page.svelte
@@ -35,7 +35,12 @@
   </div>
 
   {#if done}
-    <div class="mt-8 rounded-xl p-6 shadow-md {passed ? 'bg-emerald-50' : 'bg-amber-50'}" data-testid="assessment-result">
+    <div class="mt-8 rounded-xl p-6 shadow-md {passed ? 'celebrate bg-emerald-50' : 'bg-amber-50'}" data-testid="assessment-result">
+      {#if passed}
+        <div aria-hidden="true" class="text-xl">
+          <span class="spark">✨</span><span class="spark">🎉</span><span class="spark">✨</span>
+        </div>
+      {/if}
       <h2 class="text-lg font-bold {passed ? 'text-emerald-800' : 'text-amber-800'}">
         {passed ? '🎉 Passed!' : 'Not yet. Keep practising!'}
       </h2>


### PR DESCRIPTION
The colorize/animate/onboard follow-ups from the impeccable audit:
- colorize: page surface warmed (stone-100); semantic roles untouched
- animate: feedback verdicts pop in (180ms ease-out); passing a
  checkpoint gets the one hero moment (celebrate scale-in + three
  floating sparks); all new motion disabled under
  prefers-reduced-motion
- onboard: home momentum hero - Kezdjuk! start CTA for fresh learners,
  'Continue where you left off' with the exact next lesson otherwise,
  real-event chips (n/N lessons done, words due for review linking to
  /review). No XP theater: every number maps to a learning event.
e2e 37/37 (two new momentum tests).

Claude-Session: https://claude.ai/code/session_01EXynZSuRUWNTqmm1w29e8t
